### PR TITLE
fix: enforce no dulicate mapping entry for branch in MPT

### DIFF
--- a/mapreduce-plonky2/src/storage/mapping/branch.rs
+++ b/mapreduce-plonky2/src/storage/mapping/branch.rs
@@ -83,17 +83,16 @@ where
             // add the number of leaves this proof has processed
             n = b.add(n, proof_inputs.n());
             let child_key = proof_inputs.mpt_key();
+            let (new_key, hash, is_valid, nibble) =
+                MPTCircuit::<1, NODE_LEN>::advance_key_branch(b, &node.arr, &child_key, &headers);
+            // we always enforce it's a branch node, i.e. that it has 17 entries
+            b.connect(is_valid.target, tru.target);
             // make sure we don't process twice the same proof for same nibble
-            let nibble = child_key.current_nibble(b);
             seen_nibbles.iter().for_each(|sn| {
                 let is_equal = b.is_equal(*sn, nibble);
                 b.connect(is_equal.target, ffalse.target);
             });
             seen_nibbles.push(nibble);
-            let (new_key, hash, is_valid) =
-                MPTCircuit::<1, NODE_LEN>::advance_key_branch(b, &node.arr, &child_key, &headers);
-            // we always enforce it's a branch node, i.e. that it has 17 entries
-            b.connect(is_valid.target, tru.target);
             // we check the hash is the one exposed by the proof
             // first convert the extracted hash to packed one to compare
             let packed_hash = Array::<U32Target, PACKED_HASH_LEN> {


### PR DESCRIPTION
Fixed the MPT bug in [this Slack message](https://lagrangeworld.slack.com/archives/C06B4BN2X0U/p1709756962506999) and [related document](https://www.notion.so/lagrangelabs/Cryptographic-Documentation-85adb821f18647b2a3dc65efbe144981?pvs=4#ea91c4c3a61d4276acb5c41881b3403c):
```
Found a bug in the MPT extraction circuit that allowed an attacker to feed N
times the Same valid proof to a branch node and it would still pass. That would
have meant we could have created the equivalent database consisting only of one
mapping entry.
```