### PR TITLE
[WIP] fix: add `CommonCircuitData` to MPT proof (for test)

### DIFF
--- a/mapreduce-plonky2/src/api.rs
+++ b/mapreduce-plonky2/src/api.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use plonky2::plonk::circuit_data::CommonCircuitData;
 use plonky2::plonk::{
     circuit_data::VerifierOnlyCircuitData,
     config::{GenericConfig, PoseidonGoldilocksConfig},
@@ -56,6 +57,8 @@ pub fn generate_proof(params: &PublicParameters, input: CircuitInput) -> Result<
 pub(crate) struct ProofWithVK {
     pub(crate) proof: ProofWithPublicInputs<F, C, D>,
     #[serde(serialize_with = "serialize", deserialize_with = "deserialize")]
+    pub(crate) common: CommonCircuitData<F, D>,
+    #[serde(serialize_with = "serialize", deserialize_with = "deserialize")]
     pub(crate) vk: VerifierOnlyCircuitData<C, D>,
 }
 
@@ -74,15 +77,17 @@ impl ProofWithVK {
 impl
     From<(
         ProofWithPublicInputs<F, C, D>,
+        CommonCircuitData<F, D>,
         VerifierOnlyCircuitData<C, D>,
     )> for ProofWithVK
 {
     fn from(
-        (proof, vk): (
+        (proof, common, vk): (
             ProofWithPublicInputs<F, C, D>,
+            CommonCircuitData<F, D>,
             VerifierOnlyCircuitData<C, D>,
         ),
     ) -> Self {
-        ProofWithVK { proof, vk }
+        ProofWithVK { proof, common, vk }
     }
 }

--- a/mapreduce-plonky2/src/storage/lpn/api.rs
+++ b/mapreduce-plonky2/src/storage/lpn/api.rs
@@ -74,6 +74,7 @@ impl PublicParameters {
                 let proof = self.set.generate_proof(&self.leaf_circuit, [], [], leaf)?;
                 ProofWithVK {
                     proof,
+                    common: self.leaf_circuit.get_common_data().clone(),
                     vk: self.leaf_circuit.get_verifier_data().clone(),
                 }
                 .serialize()
@@ -89,6 +90,7 @@ impl PublicParameters {
                 )?;
                 ProofWithVK {
                     proof,
+                    common: self.node_circuit.get_common_data().clone(),
                     vk: self.node_circuit.get_verifier_data().clone(),
                 }
                 .serialize()

--- a/recursion-framework/src/framework.rs
+++ b/recursion-framework/src/framework.rs
@@ -4,7 +4,9 @@ use plonky2::{
     iop::witness::PartialWitness,
     plonk::{
         circuit_builder::CircuitBuilder,
-        circuit_data::{CircuitConfig, VerifierCircuitTarget, VerifierOnlyCircuitData},
+        circuit_data::{
+            CircuitConfig, CommonCircuitData, VerifierCircuitTarget, VerifierOnlyCircuitData,
+        },
         config::{AlgebraicHasher, GenericConfig, Hasher},
         proof::{ProofWithPublicInputs, ProofWithPublicInputsTarget},
     },
@@ -29,6 +31,9 @@ where
     F: RichField + Extendable<D>,
     C: GenericConfig<D, F = F>,
 {
+    /// Returns a reference to the `CommonCircuitData` of the circuit implementing this trait
+    fn get_common_data(&self) -> &CommonCircuitData<F, D>;
+
     /// Returns a reference to the `VerifierOnlyCircuitData` of the circuit implementing this trait
     fn get_verifier_data(&self) -> &VerifierOnlyCircuitData<C, D>;
 }
@@ -44,6 +49,10 @@ where
     [(); C::Hasher::HASH_SIZE]:,
     CLW: CircuitLogicWires<F, D, NUM_VERIFIERS>,
 {
+    fn get_common_data(&self) -> &CommonCircuitData<F, D> {
+        &self.circuit_data().common
+    }
+
     fn get_verifier_data(&self) -> &VerifierOnlyCircuitData<C, D> {
         &self.circuit_data().verifier_only
     }
@@ -55,6 +64,10 @@ where
     C: GenericConfig<D, F = F>,
     T: RecursiveCircuitInfo<F, C, D>,
 {
+    fn get_common_data(&self) -> &CommonCircuitData<F, D> {
+        (*self).get_common_data()
+    }
+
     fn get_verifier_data(&self) -> &VerifierOnlyCircuitData<C, D> {
         (*self).get_verifier_data()
     }

--- a/recursion-framework/src/framework_testing.rs
+++ b/recursion-framework/src/framework_testing.rs
@@ -6,7 +6,7 @@ use plonky2::{
     },
     plonk::{
         circuit_builder::CircuitBuilder,
-        circuit_data::{CircuitConfig, VerifierOnlyCircuitData},
+        circuit_data::{CircuitConfig, CommonCircuitData, VerifierOnlyCircuitData},
         config::{AlgebraicHasher, GenericConfig, Hasher},
         proof::{ProofWithPublicInputs, ProofWithPublicInputsTarget},
     },
@@ -179,6 +179,14 @@ where
             .collect::<Result<Vec<_>>>()?;
 
         Ok(input_proofs.try_into().unwrap())
+    }
+
+    /// Utility function to get the common data for the circuit being employed to generate the input proofs
+    /// computed by the `generate_input_proofs` method
+    pub fn common_data_for_input_proofs<const NUM_VERIFIERS: usize>(
+        &self,
+    ) -> [&CommonCircuitData<F, D>; NUM_VERIFIERS] {
+        [self.dummy_circuit.get_common_data(); NUM_VERIFIERS]
     }
 
     /// Utility function to get the verifier data for the circuit being employed to generate the input proofs


### PR DESCRIPTION
### Summary

In [gnark-plonky2-verifier example](https://github.com/succinctlabs/gnark-plonky2-verifier/blob/main/benchmark.go), `CommonCircuitData` is needed to compile [r1cs](https://github.com/succinctlabs/gnark-plonky2-verifier/blob/main/benchmark.go#L55) from [its circuit](https://github.com/succinctlabs/gnark-plonky2-verifier/blob/main/benchmark.go#L33), I think it may correspond to the [proving.key](https://github.com/succinctlabs/gnark-plonky2-verifier/blob/main/benchmark.go#L138).

### TODO
- [ ] I will try to serialize these (ProofWithPublicInputs, CommonCircuitData and VerifierOnlyCircuitData) to JSON files and run with this example.