### PR TITLE
fix: try to save the plonky2 and Groth16 proofs if debugging ENVs are set

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -472,8 +472,10 @@ checksum = "8eaf5903dcbc0a39312feb77df2ff4c76387d591b9fc7b04a238dcf8bb62639a"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
+ "js-sys",
  "num-traits",
  "serde",
+ "wasm-bindgen",
  "windows-targets 0.52.4",
 ]
 
@@ -1975,6 +1977,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bytes",
+ "chrono",
  "env_logger 0.11.3",
  "ethereum-types",
  "ethers 2.0.13",
@@ -1993,7 +1996,6 @@ dependencies = [
  "serde",
  "serde_json",
  "serial_test",
- "sha3",
 ]
 
 [[package]]

--- a/groth16-framework/Cargo.toml
+++ b/groth16-framework/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0"
 bytes = "1.5"
+chrono = "0.4"
 ethereum-types = "0.14"
 ethers = { git = "https://github.com/Lagrange-Labs/ethers-rs", default-features = false, features = ["rustls"], branch = "get-proof-0x" }
 gnark-utils = { path = "../gnark-utils" }
@@ -19,7 +20,6 @@ revm = { version = "3.5", default-features = false }
 rlp = "0.5"
 serde = "1.0"
 serde_json = "1.0"
-sha3 = "0.10"
 
 [dev-dependencies]
 env_logger = "0.11"

--- a/groth16-framework/src/debug.rs
+++ b/groth16-framework/src/debug.rs
@@ -1,0 +1,47 @@
+//! Debug configurations
+
+use anyhow::Result;
+use std::env;
+
+/// Groth16 debug configuration
+#[derive(Debug)]
+enum Groth16DebugConfig {
+    /// No debug info to output
+    None,
+    /// Only output the debug info for the errors
+    Error,
+    /// Always output the debug info
+    All,
+}
+
+impl From<String> for Groth16DebugConfig {
+    fn from(s: String) -> Self {
+        match s.to_lowercase().as_str() {
+            "all" => Self::All,
+            "error" => Self::Error,
+            _ => Self::None,
+        }
+    }
+}
+
+/// Get the Groth16 debug configuration from ENV.
+fn get_debug_config() -> Groth16DebugConfig {
+    env::var("GROTH16_DEBUG_CONFIG").unwrap_or_default().into()
+}
+
+/// Get the Groth16 debug output dir from ENV.
+pub fn get_debug_output_dir<T>(result_to_debug: &Result<T>) -> Option<String> {
+    let dir = env::var("GROTH16_DEBUG_DIR").ok();
+    if dir.is_none() {
+        return None;
+    }
+
+    let config = get_debug_config();
+    match config {
+        // Return the output dir if it's an error.
+        Groth16DebugConfig::Error => result_to_debug.as_ref().map_or(None, |_| dir),
+        // Always return the output dir.
+        Groth16DebugConfig::All => dir,
+        _ => None,
+    }
+}

--- a/groth16-framework/src/lib.rs
+++ b/groth16-framework/src/lib.rs
@@ -68,6 +68,7 @@
 use plonky2::{field::goldilocks_field::GoldilocksField, plonk::config::PoseidonGoldilocksConfig};
 
 mod compiler;
+mod debug;
 mod evm;
 mod proof;
 pub mod prover;


### PR DESCRIPTION
### Summary

Add two ENVs for debugging: `GROTH16_DEBUG_CONFIG` and `GROTH16_DEBUG_DIR`.

ENV `GROTH16_DEBUG_CONFIG` could be set to a string of `all` or `error`.
- If it's `error`, only saves the plonky2 proof if failed during the Groth16 proving.
- If it's `all`, always saves both the plonky2 and Groth16 proofs (no matter if failed to prove).
- Nothing to do if the ENVs are not set (or set to other strings).