### PR TITLE
fix: return the left padding NFT IDs in query2 Solidity test

### DIFF
--- a/groth16-framework/src/test_utils.rs
+++ b/groth16-framework/src/test_utils.rs
@@ -99,5 +99,5 @@ fn evm_verify(asset_dir: &str, proof: &Groth16Proof) {
         EVMVerifier::new(&solidity_file_path).expect("Failed to initialize the EVM verifier");
 
     let verified = verifier.verify(calldata);
-    assert!(verified);
+    assert!(verified.is_ok());
 }

--- a/groth16-framework/src/verifier/evm.rs
+++ b/groth16-framework/src/verifier/evm.rs
@@ -25,15 +25,20 @@ impl EVMVerifier {
     }
 
     /// Verify the calldata with Solidity verifier contract.
-    pub fn verify(&self, calldata: Vec<u8>) -> bool {
+    /// Return the gas_used and the output bytes if success.
+    pub fn verify(&self, calldata: Vec<u8>) -> Result<(u64, Vec<u8>)> {
         match deploy_and_call(self.deployment_code.clone(), calldata) {
-            Ok(gas_used) => {
-                log::info!("Succeeded to do EVM verification: gas_used = {gas_used}");
-                true
+            Ok(result) => {
+                log::debug!(
+                    "Succeeded to do EVM verification: gas_used = {}, output = {:?}",
+                    result.0,
+                    result.1
+                );
+                Ok(result)
             }
             Err(error) => {
                 log::error!("Failed to do EVM verification: {error}");
-                false
+                Err(error)
             }
         }
     }

--- a/groth16-framework/test_data/query2.sol
+++ b/groth16-framework/test_data/query2.sol
@@ -172,7 +172,7 @@ contract Query2 is Verifier {
     function parseNftIds(bytes memory pis) internal pure returns (uint256[] memory) {
         uint256[] memory nft_ids = new uint256[](L);
         for (uint32 i = 0; i < L; ++i) {
-            nft_ids[i] = uint256(convertToU32(pis, PI_NFT_IDS_OFFSET + i * 8));
+            nft_ids[i] = uint256(convertToLeftPaddingU32(pis, PI_NFT_IDS_OFFSET + i * 8));
         }
 
         return nft_ids;
@@ -193,6 +193,16 @@ contract Query2 is Verifier {
         uint32 result;
         for (uint32 i = 0; i < 4; ++i) {
             result |= uint32(uint8(data[i + offset])) << (8 * i);
+        }
+
+        return result;
+    }
+
+    // Convert to an uint32 of left padding from a memory offset.
+    function convertToLeftPaddingU32(bytes memory data, uint32 offset) internal pure returns (uint32) {
+        uint32 result;
+        for (uint32 i = 0; i < 4; ++i) {
+            result |= uint32(uint8(data[i + offset])) << (8 * (3 - i));
         }
 
         return result;

--- a/groth16-framework/test_data/query2_verifier.sol
+++ b/groth16-framework/test_data/query2_verifier.sol
@@ -712,7 +712,7 @@ contract Verifier {
     function parseNftIds(bytes memory pis) internal pure returns (uint256[] memory) {
         uint256[] memory nft_ids = new uint256[](L);
         for (uint32 i = 0; i < L; ++i) {
-            nft_ids[i] = uint256(convertToU32(pis, PI_NFT_IDS_OFFSET + i * 8));
+            nft_ids[i] = uint256(convertToLeftPaddingU32(pis, PI_NFT_IDS_OFFSET + i * 8));
         }
 
         return nft_ids;
@@ -733,6 +733,16 @@ contract Verifier {
         uint32 result;
         for (uint32 i = 0; i < 4; ++i) {
             result |= uint32(uint8(data[i + offset])) << (8 * i);
+        }
+
+        return result;
+    }
+
+    // Convert to an uint32 of left padding from a memory offset.
+    function convertToLeftPaddingU32(bytes memory data, uint32 offset) internal pure returns (uint32) {
+        uint32 result;
+        for (uint32 i = 0; i < 4; ++i) {
+            result |= uint32(uint8(data[i + offset])) << (8 * (3 - i));
         }
 
         return result;


### PR DESCRIPTION
### Summary

- Fix to return left padding NFT IDs in Solidity.
- Update query2 test to decode the Solidity output and check the returned NFT IDs.

Will arrange the Solidity files.