### PR TITLE
build: enable more agressive optimizations

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,9 @@
+[build]
+rustflags = ["-C", "target-cpu=native"]
+
 # Used for compile the Go code of gnark-utils on Mac.
 [target.'cfg(target_os="macos")']
-rustflags = ["-C", "link-args=-framework CoreFoundation -framework Security"]
+rustflags = [
+    "-C", "target-cpu=native",
+    "-C", "link-args=-framework CoreFoundation -framework Security",
+]

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -95,7 +95,7 @@ jobs:
         with:
           ssh-private-key: ${{ secrets.SSH_RYHOPE }}
       - name: Run cargo test
-        run: nix-shell -I /nix/var/nix/profiles/per-user/root/channels/nixos --run "eval \"$(ssh-agent -s)\" && ssh-add - <<< '${{ secrets.SSH_RYHOPE }}' && cargo test --features ci --release -- --test-threads 16"
+        run: nix-shell -I /nix/var/nix/profiles/per-user/root/channels/nixos --run "eval \"$(ssh-agent -s)\" && ssh-add - <<< '${{ secrets.SSH_RYHOPE }}' && cargo test --features ci -- --test-threads 16"
         env:
           CARGO_NET_GIT_FETCH_WITH_CLI: "true"
           RUST_LOG: "info"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,18 +64,22 @@ serial_test = "3.0"
 sha3 = "0.10"
 tokio = { version = "1.34", features = ["macros", "rt-multi-thread"] }
 
-
 # just for test
 ethers = { git = "https://github.com/Lagrange-Labs/ethers-rs", default-features = false, features = [
   "rustls",
 ], branch = "get-proof-0x" }
 
-[profile.release]
+[profile.dev]
+# Reference: https://doc.rust-lang.org/cargo/reference/profiles.html#dev
+# Proving is too slow without optimizations
 opt-level = 3
-incremental = true
 
-[profile.bench]
-opt-level = 3
+[profile.release]
+# Reference: https://doc.rust-lang.org/cargo/reference/profiles.html#release
+# Proving is a bottleneck, enable agressive optimizations.
+# Reference: https://nnethercote.github.io/perf-book/build-configuration.html#codegen-units
+codegen-units = 1
+lto = "fat"
 
 [patch.crates-io]
 plonky2 = { git = "https://github.com/Lagrange-Labs/plonky2", branch = "upstream" }

--- a/mp2-common/src/lib.rs
+++ b/mp2-common/src/lib.rs
@@ -166,3 +166,20 @@ mod test {
         Ok(())
     }
 }
+
+#[test]
+#[should_panic]
+fn test_debug_asserts_are_enabled() {
+    // Tests should be executed with `RUSTFLAGS="-C debug-assertions".
+    debug_assert!(false);
+}
+
+#[test]
+#[should_panic]
+#[allow(arithmetic_overflow)]
+fn test_overflow_panics_are_enabled() {
+    // Tests should check for overflow
+    let a = 1_u64;
+    let b = 64;
+    assert_ne!(a << b, 0);
+}


### PR DESCRIPTION
Enables more agressive optimizations because this repo does a lot of proving.

- Debug builds have optimizations enable by default
- Release builds have more agressive settings to allow for better inling.