### PR TITLE
chore: fix visibility warnings

### DIFF
--- a/mp2-v1/src/contract_extraction/leaf.rs
+++ b/mp2-v1/src/contract_extraction/leaf.rs
@@ -28,7 +28,7 @@ use serde::{Deserialize, Serialize};
 const INPUT_PADDED_ADDRESS_LEN: usize = PAD_LEN(ADDRESS_LEN);
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
-pub(crate) struct LeafWires<const NODE_LEN: usize>
+pub struct LeafWires<const NODE_LEN: usize>
 where
     [(); PAD_LEN(NODE_LEN)]:,
 {
@@ -44,7 +44,7 @@ where
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub(crate) struct LeafCircuit<const NODE_LEN: usize> {
+pub struct LeafCircuit<const NODE_LEN: usize> {
     pub(crate) contract_address: Address,
     /// The offset of storage root hash located in RLP encoded account node
     pub(crate) storage_root_offset: usize,

--- a/mp2-v1/src/final_extraction/base_circuit.rs
+++ b/mp2-v1/src/final_extraction/base_circuit.rs
@@ -105,7 +105,7 @@ pub(crate) const BLOCK_SET_NUM_IO: usize =
     block_extraction::public_inputs::PublicInputs::<F>::TOTAL_LEN;
 
 #[derive(Clone, Debug)]
-pub(super) struct BaseCircuitInput {
+pub struct BaseCircuitInput {
     block_proof: ProofWithPublicInputs<F, C, D>,
     contract_proof: ProofWithVK,
     value_proof: ProofWithVK,

--- a/mp2-v1/src/values_extraction/leaf_mapping.rs
+++ b/mp2-v1/src/values_extraction/leaf_mapping.rs
@@ -30,7 +30,7 @@ use serde::{Deserialize, Serialize};
 use std::iter;
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
-pub(crate) struct LeafMappingWires<const NODE_LEN: usize>
+pub struct LeafMappingWires<const NODE_LEN: usize>
 where
     [(); PAD_LEN(NODE_LEN)]:,
 {
@@ -57,7 +57,7 @@ where
 
 /// Circuit to prove the correct derivation of the MPT key from a mapping slot
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub(crate) struct LeafMappingCircuit<const NODE_LEN: usize> {
+pub struct LeafMappingCircuit<const NODE_LEN: usize> {
     pub(crate) node: Vec<u8>,
     pub(crate) slot: MappingSlot,
     pub(crate) key_id: u64,

--- a/mp2-v1/src/values_extraction/leaf_single.rs
+++ b/mp2-v1/src/values_extraction/leaf_single.rs
@@ -29,7 +29,7 @@ use serde::{Deserialize, Serialize};
 use std::iter;
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
-pub(crate) struct LeafSingleWires<const NODE_LEN: usize>
+pub struct LeafSingleWires<const NODE_LEN: usize>
 where
     [(); PAD_LEN(NODE_LEN)]:,
 {
@@ -51,7 +51,7 @@ where
 
 /// Circuit to prove the correct derivation of the MPT key from a simple slot
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub(crate) struct LeafSingleCircuit<const NODE_LEN: usize> {
+pub struct LeafSingleCircuit<const NODE_LEN: usize> {
     pub(crate) node: Vec<u8>,
     pub(crate) slot: SimpleSlot,
     pub(crate) id: u64,

--- a/verifiable-db/src/block_tree/leaf.rs
+++ b/verifiable-db/src/block_tree/leaf.rs
@@ -37,7 +37,7 @@ pub(crate) struct LeafWires<E> {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub(crate) struct LeafCircuit {
+pub struct LeafCircuit {
     /// Identifier of the block number column
     pub(crate) index_identifier: F,
 }

--- a/verifiable-db/src/block_tree/membership.rs
+++ b/verifiable-db/src/block_tree/membership.rs
@@ -38,7 +38,7 @@ pub(crate) struct MembershipWires {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub(crate) struct MembershipCircuit {
+pub struct MembershipCircuit {
     /// Identifier of the block number column
     pub(crate) index_identifier: F,
     /// Block number of the current node

--- a/verifiable-db/src/block_tree/parent.rs
+++ b/verifiable-db/src/block_tree/parent.rs
@@ -55,7 +55,7 @@ pub(crate) struct ParentWires {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub(crate) struct ParentCircuit {
+pub struct ParentCircuit {
     /// Identifier of the block number column
     pub(crate) index_identifier: F,
     /// Block number stored in the old node

--- a/verifiable-db/src/cells_tree/leaf.rs
+++ b/verifiable-db/src/cells_tree/leaf.rs
@@ -23,13 +23,13 @@ use serde::{Deserialize, Serialize};
 use std::iter;
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub(crate) struct LeafWires {
+pub struct LeafWires {
     identifier: Target,
     value: UInt256Target,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub(crate) struct LeafCircuit {
+pub struct LeafCircuit {
     /// The same identifier derived from the MPT extraction
     pub(crate) identifier: F,
     /// Uint256 value

--- a/verifiable-db/src/row_tree/full_node.rs
+++ b/verifiable-db/src/row_tree/full_node.rs
@@ -27,7 +27,7 @@ use super::{public_inputs::PublicInputs, IndexTuple, IndexTupleWire};
 pub struct FullNodeCircuit(IndexTuple);
 
 #[derive(Clone, Serialize, Deserialize, From, Deref)]
-struct FullNodeWires(IndexTupleWire);
+pub(crate) struct FullNodeWires(IndexTupleWire);
 
 impl FullNodeCircuit {
     pub(crate) fn build(


### PR DESCRIPTION
Fix warnings around visibility mismatches. This commit brings the visibility of the structs up to match th visiblity of the APIs.