### PR TITLE
Ignore integration test

### DIFF
--- a/mp2-v1/tests/db_creation_tests.rs
+++ b/mp2-v1/tests/db_creation_tests.rs
@@ -52,6 +52,7 @@ pub(crate) mod common;
 //}
 
 #[test(tokio::test)]
+#[ignore]
 async fn db_creation_integrated_tests() -> Result<()> {
     // Create the test context for mainnet.
     // let ctx = &mut TestContext::new_mainet();


### PR DESCRIPTION
This PR marks the big integration test with `#[ignore]` to avoid running it into the CI, as it seems the test has grown too big now and it is slowing down the CI. Should be a temporary fix to relieve the CI, then probably we need to setup another non-CI machine where devs could run the integration test if needed.