### PR TITLE
feat: ryhope PgSQL backend may be initialized from an existing pool

### DIFF
--- a/ryhope/src/storage/pgsql/mod.rs
+++ b/ryhope/src/storage/pgsql/mod.rs
@@ -130,13 +130,21 @@ impl<T: Clone + Debug> Debug for CachedValue<T> {
     }
 }
 
-/// The settings required to instantiate a [`PgsqlStorage`] from a PgSQL server.
-pub struct SqlStorageSettings {
+/// Multiple ways to get a connection to the database server.
+pub enum SqlServerConnection {
     /// Connection information to the PgSQL server; may be defined in k=v
     /// format, or as a URI.
-    pub db_url: String,
+    NewConnection(String),
+    /// An existing connection pool
+    Pool(DBPool),
+}
+
+/// The settings required to instantiate a [`PgsqlStorage`] from a PgSQL server.
+pub struct SqlStorageSettings {
     /// The table to use.
     pub table: String,
+    /// A way to connect to the DB server
+    pub source: SqlServerConnection,
 }
 
 pub struct PgsqlStorage<T: TreeTopology, V>
@@ -180,14 +188,14 @@ where
     ) -> Result<Self> {
         match init_settings {
             InitSettings::MustExist => {
-                Self::load_existing(&storage_settings.db_url, storage_settings.table).await
+                Self::load_existing(&storage_settings.source, storage_settings.table).await
             }
             InitSettings::MustNotExist(tree_state) => {
-                Self::create_new(&storage_settings.db_url, storage_settings.table, tree_state).await
+                Self::create_new(&storage_settings.source, storage_settings.table, tree_state).await
             }
             InitSettings::Reset(tree_settings) => {
                 Self::reset(
-                    &storage_settings.db_url,
+                    &storage_settings.source,
                     storage_settings.table,
                     tree_settings,
                 )
@@ -223,10 +231,12 @@ where
     /// Create a new tree storage and its associated table in the specified table.
     ///
     /// Will fail if the table already exists.
-    pub async fn create_new(db_url: &str, table: String, tree_state: T::State) -> Result<Self> {
-        debug!("connecting to {db_url}...");
-        let db_pool = Self::init_db_pool(db_url).await?;
-        debug!("connection successful.");
+    pub async fn create_new(
+        db_src: &SqlServerConnection,
+        table: String,
+        tree_state: T::State,
+    ) -> Result<Self> {
+        let db_pool = Self::init_db_pool(db_src).await?;
 
         ensure!(
             fetch_current_epoch(db_pool.clone(), &table).await.is_err(),
@@ -252,10 +262,8 @@ where
     /// Initialize the storage backend from an existing table in database.
     ///
     /// Fails if the specified table does not exist.
-    pub async fn load_existing(db_url: &str, table: String) -> Result<Self> {
-        debug!("connecting to {db_url}...");
-        let db_pool = Self::init_db_pool(db_url).await?;
-        debug!("connection successful.");
+    pub async fn load_existing(db_src: &SqlServerConnection, table: String) -> Result<Self> {
+        let db_pool = Self::init_db_pool(db_src).await?;
 
         let latest_epoch = fetch_current_epoch(db_pool.clone(), &table)
             .await
@@ -277,10 +285,12 @@ where
 
     /// Create a new tree storage and its associated table in the specified
     /// table, deleting it if it already exists.
-    pub async fn reset(db_url: &str, table: String, tree_state: T::State) -> Result<Self> {
-        debug!("connecting to {db_url}...");
-        let db_pool = Self::init_db_pool(db_url).await?;
-        debug!("connection successful.");
+    pub async fn reset(
+        db_src: &SqlServerConnection,
+        table: String,
+        tree_state: T::State,
+    ) -> Result<Self> {
+        let db_pool = Self::init_db_pool(db_src).await?;
 
         delete_storage_table(db_pool.clone(), &table).await?;
         Self::create_tables(db_pool.clone(), &table).await?;
@@ -303,17 +313,22 @@ where
     }
 
     /// Initialize a DB pool.
-    pub async fn init_db_pool(db_url: &str) -> Result<DBPool> {
-        info!("Connecting to `{db_url}`");
-        let db_manager = PostgresConnectionManager::new_from_stringlike(db_url, NoTls)
-            .with_context(|| format!("while connecting to postgreSQL with `{}`", db_url))?;
+    pub async fn init_db_pool(db_src: &SqlServerConnection) -> Result<DBPool> {
+        match db_src {
+            SqlServerConnection::NewConnection(db_url) => {
+                info!("Connecting to `{db_url}`");
+                let db_manager = PostgresConnectionManager::new_from_stringlike(db_url, NoTls)
+                    .with_context(|| format!("while connecting to postgreSQL with `{}`", db_url))?;
+                let db_pool = DBPool::builder()
+                    .build(db_manager)
+                    .await
+                    .context("while creating the db_pool")?;
+                debug!("connection successful.");
 
-        let db_pool = DBPool::builder()
-            .build(db_manager)
-            .await
-            .context("while creating the db_pool")?;
-
-        Ok(db_pool)
+                Ok(db_pool)
+            }
+            SqlServerConnection::Pool(pool) => Ok(pool.clone()),
+        }
     }
 
     /// Create the tables required to store the a tree. For a given tree, two

--- a/ryhope/src/storage/tests.rs
+++ b/ryhope/src/storage/tests.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 use crate::{
     storage::{
         memory::InMemory,
-        pgsql::{PgsqlStorage, SqlStorageSettings},
+        pgsql::{PgsqlStorage, SqlServerConnection, SqlStorageSettings},
         EpochKvStorage, PayloadStorage, RoEpochKvStorage, TreeStorage,
     },
     tree::{
@@ -87,8 +87,8 @@ async fn storage_in_pgsql() -> Result<()> {
     let mut s = MerkleTreeKvDb::<TestTree, V, Storage>::new(
         InitSettings::Reset(scapegoat::Tree::empty(Alpha::new(0.8))),
         SqlStorageSettings {
-            db_url: db_url(),
             table: "simple".to_string(),
+            source: SqlServerConnection::NewConnection(db_url()),
         },
     )
     .await?;
@@ -99,8 +99,8 @@ async fn storage_in_pgsql() -> Result<()> {
     let mut s2 = MerkleTreeKvDb::<TestTree, V, Storage>::new(
         InitSettings::MustExist,
         SqlStorageSettings {
-            db_url: db_url(),
             table: "simple".to_string(),
+            source: SqlServerConnection::NewConnection(db_url()),
         },
     )
     .await?;
@@ -218,7 +218,7 @@ async fn sbbst_storage_in_pgsql() -> Result<()> {
     let mut s_psql = MerkleTreeKvDb::<TestTree, V, SqlStorage>::new(
         InitSettings::Reset(sbbst::Tree::empty()),
         SqlStorageSettings {
-            db_url: db_url(),
+            source: SqlServerConnection::NewConnection(db_url()),
             table: "simple_sbbst".to_string(),
         },
     )
@@ -253,7 +253,7 @@ async fn sbbst_storage_in_pgsql() -> Result<()> {
     let s2 = MerkleTreeKvDb::<TestTree, V, SqlStorage>::new(
         InitSettings::MustExist,
         SqlStorageSettings {
-            db_url: db_url(),
+            source: SqlServerConnection::NewConnection(db_url()),
             table: "simple_sbbst".to_string(),
         },
     )
@@ -414,7 +414,7 @@ async fn hashes_pgsql() -> Result<()> {
         let mut s = MerkleTreeKvDb::<Tree, V, Storage>::new(
             InitSettings::Reset(Tree::empty(Alpha::fully_balanced())),
             SqlStorageSettings {
-                db_url: db_url(),
+                source: SqlServerConnection::NewConnection(db_url()),
                 table: "test_hashes".into(),
             },
         )
@@ -443,7 +443,7 @@ async fn hashes_pgsql() -> Result<()> {
         let mut s = MerkleTreeKvDb::<Tree, V, Storage>::new(
             InitSettings::MustExist,
             SqlStorageSettings {
-                db_url: db_url(),
+                source: SqlServerConnection::NewConnection(db_url()),
                 table: "test_hashes".into(),
             },
         )
@@ -498,7 +498,7 @@ async fn thousand_rows() -> Result<()> {
     let mut s = MerkleTreeKvDb::<Tree, V, Storage>::new(
         InitSettings::Reset(Tree::empty(Alpha::fully_balanced())),
         SqlStorageSettings {
-            db_url: db_url(),
+            source: SqlServerConnection::NewConnection(db_url()),
             table: "thousand".to_string(),
         },
     )
@@ -590,7 +590,7 @@ async fn aggregation_pgsql() -> Result<()> {
     let mut s = MerkleTreeKvDb::<Tree, V, Storage>::new(
         InitSettings::Reset(Tree::empty()),
         SqlStorageSettings {
-            db_url: db_url(),
+            source: SqlServerConnection::NewConnection(db_url()),
             table: "agg".to_string(),
         },
     )
@@ -690,7 +690,7 @@ async fn rollback_psql() {
     let mut s = MerkleTreeKvDb::<Tree, V, Storage>::new(
         InitSettings::Reset(Tree::empty(Alpha::new(0.7))),
         SqlStorageSettings {
-            db_url: db_url(),
+            source: SqlServerConnection::NewConnection(db_url()),
             table: "rollback".to_string(),
         },
     )
@@ -745,7 +745,7 @@ async fn initial_state() {
         let _ = MerkleTreeKvDb::<Tree, V, Storage>::new(
             InitSettings::Reset(Tree::empty(Alpha::new(0.8))),
             SqlStorageSettings {
-                db_url: db_url(),
+                source: SqlServerConnection::NewConnection(db_url()),
                 table: "empty_tree".to_string(),
             },
         )
@@ -757,7 +757,7 @@ async fn initial_state() {
         let s_init = MerkleTreeKvDb::<Tree, V, Storage>::new(
             InitSettings::MustExist,
             SqlStorageSettings {
-                db_url: db_url(),
+                source: SqlServerConnection::NewConnection(db_url()),
                 table: "empty_tree".to_string(),
             },
         )


### PR DESCRIPTION
This PR extends the SQL settings to accept initializing a PgSQL backend from an existing connnexion pool rather than systematically instantiating a new one.