### PR TITLE
fix: SBBST wide lineage computations

### DIFF
--- a/ryhope/src/storage/mod.rs
+++ b/ryhope/src/storage/mod.rs
@@ -110,14 +110,16 @@ impl<K: Debug + Hash + Eq + Clone + Sync + Send, V: Clone> WideLineage<K, V> {
                 let mut path = vec![k.clone()];
                 // ok to unwrap since we passed the filter, so that key must exist
                 // otherwise it's ryhope failure
-                let mut ctx = epoch_data.0.get(k).expect("lineage should get all keys");
+                let mut ctx = epoch_data.0.get(k).expect(&format!(
+                    "lineage should get all core keys, but {k:?} is missing"
+                ));
                 // go back up to there is no more parent anymore, i.e. the root
                 while ctx.parent.is_some() {
                     let parent_k = ctx.parent.as_ref().unwrap();
                     ctx = epoch_data
                         .0
                         .get(parent_k)
-                        .expect("lineage should get all keys");
+                        .expect(&format!("lineage should get all ascendant keys, but {parent_k:?} (for {k:?}) is missing"));
                     path.push(parent_k.clone());
                 }
                 // NOTE: these paths are *ascending*, whereas the update tree is

--- a/ryhope/src/storage/mod.rs
+++ b/ryhope/src/storage/mod.rs
@@ -110,7 +110,7 @@ impl<K: Debug + Hash + Eq + Clone + Sync + Send, V: Clone> WideLineage<K, V> {
                 let mut path = vec![k.clone()];
                 // ok to unwrap since we passed the filter, so that key must exist
                 // otherwise it's ryhope failure
-                let mut ctx = epoch_data.0.get(k).expect(&format!(
+                let mut ctx = epoch_data.0.get(k).unwrap_or_else(|| panic!(
                     "lineage should get all core keys, but {k:?} is missing"
                 ));
                 // go back up to there is no more parent anymore, i.e. the root
@@ -119,7 +119,7 @@ impl<K: Debug + Hash + Eq + Clone + Sync + Send, V: Clone> WideLineage<K, V> {
                     ctx = epoch_data
                         .0
                         .get(parent_k)
-                        .expect(&format!("lineage should get all ascendant keys, but {parent_k:?} (for {k:?}) is missing"));
+                        .unwrap_or_else(|| panic!("lineage should get all ascendant keys, but {parent_k:?} (for {k:?}) is missing"));
                     path.push(parent_k.clone());
                 }
                 // NOTE: these paths are *ascending*, whereas the update tree is

--- a/ryhope/src/storage/pgsql/storages.rs
+++ b/ryhope/src/storage/pgsql/storages.rs
@@ -148,13 +148,13 @@ where
                 .join(", ");
             Ok(connection
             .query(
-                &dbg!(format!(
+                &format!(
                    "SELECT batch.key, batch.epoch, {table}.{PAYLOAD} FROM
                      (VALUES {}) AS batch (epoch, key)
                      LEFT JOIN {table} ON
                      batch.key = {table}.{KEY} AND {table}.{VALID_FROM} <= batch.epoch AND batch.epoch <= {table}.{VALID_UNTIL}",
                    immediate_table
-               )),
+               ),
                 &[],
             )
                .await
@@ -286,7 +286,7 @@ where
             "SELECT
                {KEY}, generate_series(GREATEST({VALID_FROM}, $1), LEAST({VALID_UNTIL}, $2)) AS epoch, {PAYLOAD}
              FROM {table}
-             WHERE {VALID_FROM} <= $1 AND $2 <= {VALID_UNTIL} AND {KEY} = ANY($3)",
+             WHERE NOT ({VALID_FROM} > $2 OR {VALID_UNTIL} < $1) AND {KEY} = ANY($3)",
         );
         let rows = db
             .get()

--- a/ryhope/src/tree/sbbst.rs
+++ b/ryhope/src/tree/sbbst.rs
@@ -122,7 +122,7 @@ impl State {
             if inner_idx <= inner_max {
                 if let Some(lineage) = self.lineage_inner(&inner_idx) {
                     for n in lineage.into_full_path() {
-                        if n < inner_max {
+                        if n <= inner_max {
                             ascendance.insert(self.outer_idx(n));
                         }
                     }


### PR DESCRIPTION
Two bugs compounding each other:

1. a `<` instead of `<=` comparison for tree belonging in the SBBST erroneously excluding the latest node;

2. an erroneous implementation of interval overlap in SQL excluding nodes whose lifetime overlaps the target interval, but are not completely included in it.