### PR TITLE
fix lint `async_fn_in_trait`

### DIFF
--- a/ryhope/src/storage/mod.rs
+++ b/ryhope/src/storage/mod.rs
@@ -42,10 +42,10 @@ where
 {
     type Settings;
 
-    async fn from_settings(
+    fn from_settings(
         init_settings: InitSettings<T>,
         storage_settings: Self::Settings,
-    ) -> Result<Self>;
+    ) -> impl Future<Output = Result<Self>>;
 }
 
 pub struct WideLineage<K, V>
@@ -158,15 +158,15 @@ pub trait TreeStorage<T: TreeTopology>: Sized + Send + Sync {
     fn nodes_mut(&mut self) -> &mut Self::NodeStorage;
 
     /// Return a list of the nodes “born” (i.e. dirtied) at `epoch`.
-    async fn born_at(&self, epoch: Epoch) -> Vec<T::Key>;
+    fn born_at(&self, epoch: Epoch) -> impl Future<Output = Vec<T::Key>>;
 
     /// Rollback this tree one epoch in the past
-    async fn rollback<F>(&mut self) -> Result<()> {
-        self.rollback_to(self.nodes().current_epoch() - 1).await
+    fn rollback<F>(&mut self) -> impl Future<Output = Result<()>> {
+        self.rollback_to(self.nodes().current_epoch() - 1)
     }
 
     /// Rollback this tree to the given epoch
-    async fn rollback_to(&mut self, epoch: Epoch) -> Result<()>;
+    fn rollback_to(&mut self, epoch: Epoch) -> impl Future<Output = Result<()>>;
 
     /// Return an epoch-locked, read-only, [`TreeStorage`] offering a view on
     /// this Merkle tree as it was at the given epoch.
@@ -216,12 +216,12 @@ where
     }
 
     /// Roll back this storage one epoch in the past.
-    async fn rollback(&mut self) -> Result<()> {
-        self.rollback_to(self.current_epoch() - 1).await
+    fn rollback(&mut self) -> impl Future<Output = Result<()>> {
+        self.rollback_to(self.current_epoch() - 1)
     }
 
     /// Roll back this storage to the given epoch
-    async fn rollback_to(&mut self, epoch: Epoch) -> Result<()>;
+    fn rollback_to(&mut self, epoch: Epoch) -> impl Future<Output = Result<()>>;
 }
 
 /// A read-only, versioned, KV storage. Intended to be implemented in
@@ -272,24 +272,24 @@ where
         <I as IntoIterator>::IntoIter: Send;
 
     /// Return whether the given key is present at the current epoch.
-    async fn contains(&self, k: &K) -> bool {
-        self.try_fetch(k).await.is_some()
+    fn contains(&self, k: &K) -> impl Future<Output = bool> {
+        async { self.try_fetch(k).await.is_some() }
     }
 
     /// Return whether the given key is present at the given epoch.
-    async fn contains_at(&self, k: &K, epoch: Epoch) -> bool {
-        self.try_fetch_at(k, epoch).await.is_some()
+    fn contains_at(&self, k: &K, epoch: Epoch) -> impl Future<Output = bool> {
+        async move { self.try_fetch_at(k, epoch).await.is_some() }
     }
 
     /// Return the number of stored K/V pairs at the current epoch.
-    async fn size(&self) -> usize {
-        self.size_at(self.current_epoch()).await
+    fn size(&self) -> impl Future<Output = usize> {
+        self.size_at(self.current_epoch())
     }
 
     /// Return the number of stored K/V pairs at the gievm epoch
-    async fn size_at(&self, epoch: Epoch) -> usize;
+    fn size_at(&self, epoch: Epoch) -> impl Future<Output = usize>;
 
-    async fn keys_at(&self, epoch: Epoch) -> Vec<K>;
+    fn keys_at(&self, epoch: Epoch) -> impl Future<Output = Vec<K>>;
 }
 
 /// A versioned KV storage only allowed to mutate entries only in the current
@@ -332,13 +332,13 @@ pub trait EpochKvStorage<K: Eq + Hash + Send + Sync, V: Send + Sync>:
 
     /// Rollback this storage one epoch back. Please note that this is a
     /// destructive and irreversible operation.
-    async fn rollback(&mut self) -> Result<()> {
-        self.rollback_to(self.current_epoch() - 1).await
+    fn rollback(&mut self) -> impl Future<Output = Result<()>> {
+        self.rollback_to(self.current_epoch() - 1)
     }
 
     /// Rollback this storage to the given epoch. Please note that this is a
     /// destructive and irreversible operation.
-    async fn rollback_to(&mut self, epoch: Epoch) -> Result<()>;
+    fn rollback_to(&mut self, epoch: Epoch) -> impl Future<Output = Result<()>>;
 }
 
 /// Characterizes a trait allowing for epoch-based atomic updates.
@@ -349,18 +349,23 @@ pub trait TransactionalStorage {
 
     /// Closes the current transaction and commit to the new state at the new
     /// epoch.
-    async fn commit_transaction(&mut self) -> Result<()>;
+    fn commit_transaction(&mut self) -> impl Future<Output = Result<()>>;
 
     /// Execute the given function acting on `Self` within a transaction.
     ///
     /// Will fail if the transaction failed.
-    async fn in_transaction<Fut, F: FnOnce(&mut Self) -> Fut>(&mut self, f: F) -> Result<()>
+    fn in_transaction<Fut, F: FnOnce(&mut Self) -> Fut>(
+        &mut self,
+        f: F,
+    ) -> impl Future<Output = Result<()>>
     where
         Fut: Future<Output = Result<()>>,
     {
-        self.start_transaction()?;
-        f(self).await?;
-        self.commit_transaction().await
+        async {
+            self.start_transaction()?;
+            f(self).await?;
+            self.commit_transaction().await
+        }
     }
 }
 
@@ -370,7 +375,7 @@ pub trait TransactionalStorage {
 pub trait SqlTransactionStorage: TransactionalStorage {
     /// Similar to the [`commit`] method of [`TransactionalStorage`], but
     /// re-using a given transaction.
-    async fn commit_in(&mut self, tx: &mut Transaction<'_>) -> Result<()>;
+    fn commit_in(&mut self, tx: &mut Transaction<'_>) -> impl Future<Output = Result<()>>;
 
     /// Types implementing this trait may implement this method if there is code
     /// they want to have run after the transaction successful execution, _e.g._
@@ -394,26 +399,28 @@ pub trait TreeTransactionalStorage<K: Clone + Hash + Eq + Send + Sync, V: Send +
 {
     /// Start a new transaction, defining a transition between the storage at
     /// two epochs.
-    async fn start_transaction(&mut self) -> Result<()>;
+    fn start_transaction(&mut self) -> impl Future<Output = Result<()>>;
 
     /// Closes the current transaction and commit to the new state at the new
     /// epoch.
     ///
     /// Return the hierarchy of `Key` affected by the transaction and requiring
     /// a re-proof.
-    async fn commit_transaction(&mut self) -> Result<UpdateTree<K>>;
+    fn commit_transaction(&mut self) -> impl Future<Output = Result<UpdateTree<K>>>;
 
     /// Execute the given function acting on `Self` within a transaction.
     ///
     /// Will fail if the transaction failed.
 
-    async fn in_transaction<F: FnOnce(&mut Self) -> BoxFuture<'_, Result<()>> + Sync>(
+    fn in_transaction<F: FnOnce(&mut Self) -> BoxFuture<'_, Result<()>> + Sync>(
         &mut self,
         f: F,
-    ) -> Result<UpdateTree<K>> {
-        self.start_transaction().await?;
-        f(self).await?;
-        self.commit_transaction().await
+    ) -> impl Future<Output = Result<UpdateTree<K>>> {
+        async {
+            self.start_transaction().await?;
+            f(self).await?;
+            self.commit_transaction().await
+        }
     }
 
     /// Consume an iterator of [`Operation<K>`] and apply all of them within a
@@ -423,19 +430,21 @@ pub trait TreeTransactionalStorage<K: Clone + Hash + Eq + Send + Sync, V: Send +
     /// a re-proof.
     ///
     /// Fail if any of the operation fails.
-    async fn transaction_from_batch<I: IntoIterator<Item = Operation<K, V>>>(
+    fn transaction_from_batch<I: IntoIterator<Item = Operation<K, V>>>(
         &mut self,
         ops: I,
-    ) -> Result<UpdateTree<K>> {
-        self.start_transaction().await?;
-        for op in ops.into_iter() {
-            match op {
-                Operation::Insert(k, v) => self.store(k, v).await?,
-                Operation::Delete(k) => self.remove(k).await?,
-                Operation::Update(k, v) => self.update(k, v).await?,
+    ) -> impl Future<Output = Result<UpdateTree<K>>> {
+        async {
+            self.start_transaction().await?;
+            for op in ops.into_iter() {
+                match op {
+                    Operation::Insert(k, v) => self.store(k, v).await?,
+                    Operation::Delete(k) => self.remove(k).await?,
+                    Operation::Update(k, v) => self.update(k, v).await?,
+                }
             }
+            self.commit_transaction().await
         }
-        self.commit_transaction().await
     }
 }
 
@@ -454,7 +463,10 @@ pub trait SqlTreeTransactionalStorage<K: Clone + Hash + Eq + Send + Sync, V: Sen
 {
     /// Similar to the [`commit`] method of [`TreeTransactionalStorage`], but
     /// re-using a given transaction.
-    async fn commit_in(&mut self, tx: &mut Transaction<'_>) -> Result<UpdateTree<K>>;
+    fn commit_in(
+        &mut self,
+        tx: &mut Transaction<'_>,
+    ) -> impl Future<Output = Result<UpdateTree<K>>>;
 
     /// Types implementing this trait may implement this method if there is code
     /// they want to have run after the transaction successful execution, _e.g._
@@ -482,28 +494,30 @@ pub trait MetaOperations<T: TreeTopology, V: Send + Sync>:
 
     /// Fetch the subtree defined as the 2-depth extension of the subtree formed
     /// by the union of all the paths-to-the-root for the given keys.
-    async fn wide_lineage_between(
+    fn wide_lineage_between(
         &self,
         at: Epoch,
         t: &T,
         keys: &Self::KeySource,
         bounds: (Epoch, Epoch),
-    ) -> Result<WideLineage<T::Key, V>>;
+    ) -> impl Future<Output = Result<WideLineage<T::Key, V>>>;
 
-    async fn wide_update_trees(
+    fn wide_update_trees(
         &self,
         at: Epoch,
         t: &T,
         keys: &Self::KeySource,
         bounds: (Epoch, Epoch),
-    ) -> Result<Vec<UpdateTree<T::Key>>> {
-        let wide_lineage = self.wide_lineage_between(at, t, keys, bounds).await?;
-        let mut r = Vec::new();
-        for (epoch, nodes) in wide_lineage.epoch_lineages.iter() {
-            if let Some(root) = t.root(&self.view_at(*epoch)).await {
-                r.push(UpdateTree::from_map(*epoch, &root, &nodes.0));
+    ) -> impl Future<Output = Result<Vec<UpdateTree<T::Key>>>> {
+        async move {
+            let wide_lineage = self.wide_lineage_between(at, t, keys, bounds).await?;
+            let mut r = Vec::new();
+            for (epoch, nodes) in wide_lineage.epoch_lineages.iter() {
+                if let Some(root) = t.root(&self.view_at(*epoch)).await {
+                    r.push(UpdateTree::from_map(*epoch, &root, &nodes.0));
+                }
             }
+            Ok(r)
         }
-        Ok(r)
     }
 }

--- a/ryhope/src/tree/mod.rs
+++ b/ryhope/src/tree/mod.rs
@@ -38,75 +38,83 @@ pub trait TreeTopology: Default + Send + Sync {
     type State: Send + Sync + Clone + Debug + Serialize + for<'a> Deserialize<'a>;
 
     /// Return the number of nodes currently stored in the tree
-    async fn size<S: TreeStorage<Self>>(&self, s: &S) -> usize;
+    fn size<S: TreeStorage<Self>>(&self, s: &S) -> impl Future<Output = usize>;
 
     /// Return the root of the tree.
     ///
     /// May be empty, e.g. if the tree is empty.
-    async fn root<S: TreeStorage<Self>>(&self, s: &S) -> Option<Self::Key>;
+    fn root<S: TreeStorage<Self>>(&self, s: &S) -> impl Future<Output = Option<Self::Key>>;
 
     /// Return the parent of `n`, or None if `n` is the root of the tree.
-    async fn parent<S: TreeStorage<Self>>(&self, n: Self::Key, s: &S) -> Option<Self::Key>;
+    fn parent<S: TreeStorage<Self>>(
+        &self,
+        n: Self::Key,
+        s: &S,
+    ) -> impl Future<Output = Option<Self::Key>>;
 
     /// Return whether `k` exists in the tree.
-    async fn contains<S: TreeStorage<Self>>(&self, k: &Self::Key, s: &S) -> bool;
+    fn contains<S: TreeStorage<Self>>(&self, k: &Self::Key, s: &S) -> impl Future<Output = bool>;
 
     /// Return, if it has some, the children of `k`.
     ///
     /// Return nothing if `k` is not in the tree.
-    async fn children<S: TreeStorage<Self>>(
+    fn children<S: TreeStorage<Self>>(
         &self,
         k: &Self::Key,
         s: &S,
-    ) -> Option<(Option<Self::Key>, Option<Self::Key>)>;
+    ) -> impl Future<Output = Option<(Option<Self::Key>, Option<Self::Key>)>>;
 
     /// Return a set of `n` and its descendants, if any, up to `depth` levels
     /// down.
-    async fn descendance<S: TreeStorage<Self>>(
+    fn descendance<S: TreeStorage<Self>>(
         &self,
         s: &S,
         n: &Self::Key,
         depth: usize,
-    ) -> HashSet<Self::Key> {
-        let mut todos = vec![(n.to_owned(), 0)];
-        let mut descendance = HashSet::new();
-        while let Some(todo) = todos.pop() {
-            let current_depth = todo.1;
-            if current_depth <= depth {
-                if let Some(children) = self.children(&todo.0, s).await {
-                    for child in [children.0, children.1] {
-                        if let Some(child) = child {
-                            todos.push((child, current_depth + 1));
+    ) -> impl Future<Output = HashSet<Self::Key>> {
+        async move {
+            let mut todos = vec![(n.to_owned(), 0)];
+            let mut descendance = HashSet::new();
+            while let Some(todo) = todos.pop() {
+                let current_depth = todo.1;
+                if current_depth <= depth {
+                    if let Some(children) = self.children(&todo.0, s).await {
+                        for child in [children.0, children.1] {
+                            if let Some(child) = child {
+                                todos.push((child, current_depth + 1));
+                            }
                         }
                     }
+                    descendance.insert(todo.0);
                 }
-                descendance.insert(todo.0);
             }
-        }
 
-        descendance
+            descendance
+        }
     }
 
     /// Returns the [`NodePath`] from the root of the tree to `k`.
-    async fn lineage<S: TreeStorage<Self>>(
+    fn lineage<S: TreeStorage<Self>>(
         &self,
         k: &Self::Key,
         s: &S,
-    ) -> Option<NodePath<Self::Key>>;
+    ) -> impl Future<Output = Option<NodePath<Self::Key>>>;
 
     /// Return the union of the lineages of all the `ns`
-    async fn ascendance<S: TreeStorage<Self>, I: IntoIterator<Item = Self::Key>>(
+    fn ascendance<S: TreeStorage<Self>, I: IntoIterator<Item = Self::Key>>(
         &self,
         ns: I,
         s: &S,
-    ) -> HashSet<Self::Key> {
-        let mut ascendance = HashSet::new();
-        for n in ns.into_iter() {
-            if let Some(np) = self.lineage(&n, s).await {
-                ascendance.extend(np.into_full_path());
+    ) -> impl Future<Output = HashSet<Self::Key>> {
+        async {
+            let mut ascendance = HashSet::new();
+            for n in ns.into_iter() {
+                if let Some(np) = self.lineage(&n, s).await {
+                    ascendance.extend(np.into_full_path());
+                }
             }
+            ascendance
         }
-        ascendance
     }
 
     /// Return the immediate neighborhood of the given `k`, if it exists, in the
@@ -170,11 +178,17 @@ impl<K> NodeContext<K> {
 }
 
 pub trait PrintableTree: TreeTopology {
-    async fn print<S: TreeStorage<Self>>(&self, s: &S) {
-        println!("{}", self.tree_to_string(s).await);
+    fn print<S: TreeStorage<Self>>(&self, s: &S) -> impl Future<Output = ()> {
+        async {
+            println!("{}", self.tree_to_string(s).await);
+        }
     }
 
-    async fn tree_to_string<S: TreeStorage<Self>>(&self, s: &S) -> String;
+    fn tree_to_string<S: TreeStorage<Self>>(&self, s: &S) -> impl Future<Output = String>;
 
-    async fn subtree_to_string<S: TreeStorage<Self>>(&self, s: &S, k: &Self::Key) -> String;
+    fn subtree_to_string<S: TreeStorage<Self>>(
+        &self,
+        s: &S,
+        k: &Self::Key,
+    ) -> impl Future<Output = String>;
 }


### PR DESCRIPTION
Fix lint as:
```
help: you can alternatively desugar to a normal `fn` that returns `impl Future` and add any desired bounds such as `Send`, but these cannot be relaxed without a breaking API change
    |
179 -     async fn subtree_to_string<S: TreeStorage<Self>>(&self, s: &S, k: &Self::Key) -> String;
179 +     fn subtree_to_string<S: TreeStorage<Self>>(&self, s: &S, k: &Self::Key) -> impl std::future::Future<Output = String> + Send;
    |
```