### PR TITLE
perf: implement batched fetch operations 

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -9,41 +9,41 @@ name: Check, Test, and Format
 
 jobs:
   fmt:
-    name: Rustfmt
-    runs-on: ['memory:128GB']
+    runs-on: ['memory:8GB']
     steps:
-      - run: sudo apt-get update && sudo apt-get install -yq pkg-config libssl-dev
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
-        with:
-          go-version: ~1.20
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: nightly-2024-05-17
-          override: true
-      - run: rustup component add rustfmt
-      - uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+      - name: Checkout sources
+        uses: actions/checkout@v4
+      - name: Install devenv
+        run: |
+          if [ -e /nix/var/nix/profiles/default/bin/nix-env ]
+          then
+              /nix/var/nix/profiles/default/bin/nix-env -if https://github.com/cachix/devenv/tarball/latest
+          else
+              nix-env -if https://github.com/cachix/devenv/tarball/latest
+          fi
+          echo "$HOME/.nix-profile/bin" >> $GITHUB_PATH
+      - name: Run cargo test
+        shell: devenv shell bash -- -e {0}
+        run: cargo fmt --all -- --check #
 
   check:
     name: Check
-    runs-on: ['memory:128GB']
+    runs-on: ['memory:8GB']
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-go@v5
-        with:
-          go-version: ~1.20
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: nightly-2024-05-17
-          override: true
-      - uses: actions-rs/cargo@v1
-        with:
-          command: check
+      - name: Checkout sources
+        uses: actions/checkout@v4
+      - name: Install devenv
+        run: |
+          if [ -e /nix/var/nix/profiles/default/bin/nix-env ]
+          then
+              /nix/var/nix/profiles/default/bin/nix-env -if https://github.com/cachix/devenv/tarball/latest
+          else
+              nix-env -if https://github.com/cachix/devenv/tarball/latest
+          fi
+          echo "$HOME/.nix-profile/bin" >> $GITHUB_PATH
+      - name: Run cargo check
+        shell: devenv shell bash -- -e {0}
+        run: cargo check --tests
 
   test:
     name: Test Suite

--- a/ryhope/src/lib.rs
+++ b/ryhope/src/lib.rs
@@ -290,6 +290,22 @@ impl<
         self.tree.lineage(k, &s).await
     }
 
+    /// Return the union of the lineages of the keys in the given iterator at
+    /// the specified epoch.
+    pub async fn ascendance_at<I: IntoIterator<Item = T::Key>>(
+        &self,
+        ks: I,
+        epoch: Epoch,
+    ) -> HashSet<T::Key> {
+        self.tree.ascendance(ks, &self.view_at(epoch)).await
+    }
+
+    /// Return a handle to this merkle tree storage, as it stands at its most
+    /// recent epoch.
+    pub fn now(&self) -> &S {
+        &self.storage
+    }
+
     /// Return an epoch-locked, read-only, [`TreeStorage`] offering a view on
     /// this Merkle tree as it was at the given epoch.
     pub fn view_at(&self, epoch: Epoch) -> TreeStorageView<'_, T, S> {
@@ -316,16 +332,6 @@ impl<
             Some(ut)
         }
     }
-
-    pub async fn try_fetch_many_at<I: IntoIterator<Item = (Epoch, T::Key)> + Send>(
-        &self,
-        data: I,
-    ) -> Result<Vec<Option<(Epoch, T::Key, V)>>>
-    where
-        <I as IntoIterator>::IntoIter: Send,
-    {
-        self.storage.data().try_fetch_many_at(data).await
-    }
 }
 
 impl<
@@ -347,6 +353,16 @@ impl<
         self.storage
             .wide_update_trees(at, &self.tree, keys_query, bounds)
             .await
+    }
+
+    pub async fn try_fetch_many_at<I: IntoIterator<Item = (Epoch, T::Key)> + Send>(
+        &self,
+        data: I,
+    ) -> Result<Vec<(Epoch, NodeContext<T::Key>, V)>>
+    where
+        <I as IntoIterator>::IntoIter: Send,
+    {
+        self.storage.try_fetch_many_at(&self.tree, data).await
     }
 
     pub async fn wide_lineage_between(
@@ -388,16 +404,6 @@ impl<
 
     async fn try_fetch_at(&self, k: &T::Key, epoch: Epoch) -> Option<V> {
         self.storage.data().try_fetch_at(k, epoch).await
-    }
-
-    async fn try_fetch_many_at<I: IntoIterator<Item = (Epoch, T::Key)> + Send>(
-        &self,
-        data: I,
-    ) -> Result<Vec<Option<(Epoch, T::Key, V)>>>
-    where
-        <I as IntoIterator>::IntoIter: Send,
-    {
-        self.storage.data().try_fetch_many_at(data).await
     }
 
     async fn size_at(&self, epoch: Epoch) -> usize {

--- a/ryhope/src/lib.rs
+++ b/ryhope/src/lib.rs
@@ -1,7 +1,12 @@
 use anyhow::*;
 use futures::{stream, StreamExt};
 use serde::{Deserialize, Serialize};
-use std::{collections::HashSet, fmt::Debug, hash::Hash, marker::PhantomData};
+use std::{
+    collections::{HashMap, HashSet},
+    fmt::Debug,
+    hash::Hash,
+    marker::PhantomData,
+};
 use storage::{
     updatetree::{Next, UpdatePlan, UpdateTree},
     view::TreeStorageView,
@@ -412,6 +417,10 @@ impl<
 
     async fn keys_at(&self, epoch: Epoch) -> Vec<T::Key> {
         self.storage.data().keys_at(epoch).await
+    }
+
+    async fn pairs_at(&self, epoch: Epoch) -> Result<HashMap<T::Key, V>> {
+        self.storage.data().pairs_at(epoch).await
     }
 }
 

--- a/ryhope/src/storage/memory.rs
+++ b/ryhope/src/storage/memory.rs
@@ -206,7 +206,7 @@ where
         let epoch = epoch - self.epoch_offset;
         let mut keys = HashSet::new();
 
-        for i in (0..=epoch as usize).rev() {
+        for i in 0..=epoch as usize {
             keys.extend(self.mem[i].keys())
         }
 
@@ -218,11 +218,26 @@ where
         let epoch = epoch - self.epoch_offset;
         let mut keys = HashSet::new();
 
-        for i in (0..=epoch as usize).rev() {
+        for i in 0..=epoch as usize {
             keys.extend(self.mem[i].keys())
         }
 
         keys.into_iter().cloned().collect()
+    }
+
+    async fn pairs_at(&self, epoch: Epoch) -> Result<HashMap<K, V>> {
+        assert!(epoch >= self.epoch_offset);
+        let mut pairs = HashMap::new();
+        for i in 0..=epoch as usize {
+            for (k, v) in self.mem[i].iter() {
+                if let Some(v) = v.clone() {
+                    pairs.insert(k.clone(), v);
+                } else {
+                    pairs.remove(k);
+                }
+            }
+        }
+        Ok(pairs)
     }
 }
 

--- a/ryhope/src/storage/memory.rs
+++ b/ryhope/src/storage/memory.rs
@@ -184,22 +184,6 @@ where
         None
     }
 
-    async fn try_fetch_many_at<I: IntoIterator<Item = (Epoch, K)> + Send>(
-        &self,
-        data: I,
-    ) -> Result<Vec<Option<(Epoch, K, V)>>>
-    where
-        <I as IntoIterator>::IntoIter: Send,
-    {
-        let mut r = Vec::new();
-        for (epoch, k) in data.into_iter() {
-            let v = self.try_fetch_at(&k, epoch).await;
-
-            r.push(v.map(|v| (epoch, k, v)));
-        }
-        Ok(r)
-    }
-
     // Expensive, but only used in test context.
     async fn size(&self) -> usize {
         let all_keys = self

--- a/ryhope/src/storage/mod.rs
+++ b/ryhope/src/storage/mod.rs
@@ -263,14 +263,6 @@ where
     /// `None` otherwise.
     fn try_fetch_at(&self, k: &K, epoch: Epoch) -> impl Future<Output = Option<V>> + Send;
 
-    /// Return the value associated to a list `(Epoch, Key)` pairs, if they exist.
-    fn try_fetch_many_at<I: IntoIterator<Item = (Epoch, K)> + Send>(
-        &self,
-        data: I,
-    ) -> impl Future<Output = Result<Vec<Option<(Epoch, K, V)>>>> + Send
-    where
-        <I as IntoIterator>::IntoIter: Send;
-
     /// Return whether the given key is present at the current epoch.
     fn contains(&self, k: &K) -> impl Future<Output = bool> {
         async { self.try_fetch(k).await.is_some() }
@@ -520,4 +512,12 @@ pub trait MetaOperations<T: TreeTopology, V: Send + Sync>:
             Ok(r)
         }
     }
+
+    fn try_fetch_many_at<I: IntoIterator<Item = (Epoch, T::Key)> + Send>(
+        &self,
+        t: &T,
+        data: I,
+    ) -> impl Future<Output = Result<Vec<(Epoch, NodeContext<T::Key>, V)>>> + Send
+    where
+        <I as IntoIterator>::IntoIter: Send;
 }

--- a/ryhope/src/storage/mod.rs
+++ b/ryhope/src/storage/mod.rs
@@ -278,10 +278,16 @@ where
         self.size_at(self.current_epoch())
     }
 
-    /// Return the number of stored K/V pairs at the gievm epoch
+    /// Return the number of stored K/V pairs at the given epoch.
     fn size_at(&self, epoch: Epoch) -> impl Future<Output = usize>;
 
+    /// Return all the keys existing at the given epoch.
     fn keys_at(&self, epoch: Epoch) -> impl Future<Output = Vec<K>>;
+
+    /// Return all the valid key/value pairs at the given `epoch`.
+    ///
+    /// NOTE: be careful when using this function, it is not lazy.
+    fn pairs_at(&self, epoch: Epoch) -> impl Future<Output = Result<HashMap<K, V>>>;
 }
 
 /// A versioned KV storage only allowed to mutate entries only in the current

--- a/ryhope/src/storage/pgsql/storages.rs
+++ b/ryhope/src/storage/pgsql/storages.rs
@@ -152,49 +152,6 @@ where
         }
     }
 
-    /// Return the value associated to the given key at the given epoch.
-    fn fetch_many_payload_at<I: IntoIterator<Item = (Epoch, Self::Key)> + Send>(
-        db: DBPool,
-        table: &str,
-        data: I,
-    ) -> impl std::future::Future<Output = Result<Vec<Option<(Epoch, Self::Key, V)>>>> + std::marker::Send
-    {
-        async move {
-            let data = data.into_iter().collect::<Vec<_>>();
-            let connection = db.get().await.unwrap();
-            let immediate_table = data
-                .iter()
-                .map(|(epoch, key)| {
-                    format!(
-                        "({epoch}::BIGINT, '\\x{}'::BYTEA)",
-                        hex::encode(key.to_bytea())
-                    )
-                })
-                .join(", ");
-            Ok(connection
-            .query(
-                &format!(
-                   "SELECT batch.key, batch.epoch, {table}.{PAYLOAD} FROM
-                     (VALUES {}) AS batch (epoch, key)
-                     LEFT JOIN {table} ON
-                     batch.key = {table}.{KEY} AND {table}.{VALID_FROM} <= batch.epoch AND batch.epoch <= {table}.{VALID_UNTIL}",
-                   immediate_table
-               ),
-                &[],
-            )
-               .await
-               .context("while fetching payload from database")?
-               .iter()
-               .map(|row| {
-                   let k = Self::Key::from_bytea(row.get::<_, Vec<u8>>(0));
-                   let epoch = row.get::<_, Epoch>(1);
-                   let v = row.get::<_, Option<Json<V>>>(2).map(|x| x.0);
-                   v.map(|v| (epoch, k, v))
-               })
-               .collect())
-        }
-    }
-
     /// Given a PgSQL row, extract a value from it.
     fn payload_from_row(row: &Row) -> Result<V> {
         row.try_get::<_, Json<V>>(PAYLOAD)
@@ -212,6 +169,15 @@ where
         keys_query: &str,
         bounds: (Epoch, Epoch),
     ) -> impl Future<Output = Result<WideLineage<Self::Key, V>>>;
+
+    /// Return the value associated to the given key at the given epoch.
+    fn fetch_many_at<S: TreeStorage<Self>, I: IntoIterator<Item = (Epoch, Self::Key)> + Send>(
+        &self,
+        s: &S,
+        db: DBPool,
+        table: &str,
+        data: I,
+    ) -> impl Future<Output = Result<Vec<(Epoch, NodeContext<Self::Key>, V)>>> + Send;
 }
 
 /// Implementation of a [`DbConnector`] for a tree over `K` with empty nodes.
@@ -356,6 +322,52 @@ where
             core_keys,
             epoch_lineages,
         })
+    }
+
+    fn fetch_many_at<S: TreeStorage<Self>, I: IntoIterator<Item = (Epoch, Self::Key)> + Send>(
+        &self,
+        s: &S,
+        db: DBPool,
+        table: &str,
+        data: I,
+    ) -> impl Future<Output = Result<Vec<(Epoch, NodeContext<Self::Key>, V)>>> + Send {
+        async move {
+            let data = data.into_iter().collect::<Vec<_>>();
+            let connection = db.get().await.unwrap();
+            let immediate_table = data
+                .iter()
+                .map(|(epoch, key)| {
+                    format!(
+                        "({epoch}::BIGINT, '\\x{}'::BYTEA)",
+                        hex::encode(key.to_bytea())
+                    )
+                })
+                .join(", ");
+
+            let mut r = Vec::new();
+            for row in connection
+            .query(
+                &dbg!(format!(
+                   "SELECT batch.key, batch.epoch, {table}.{PAYLOAD} FROM
+                     (VALUES {}) AS batch (epoch, key)
+                     LEFT JOIN {table} ON
+                     batch.key = {table}.{KEY} AND {table}.{VALID_FROM} <= batch.epoch AND batch.epoch <= {table}.{VALID_UNTIL}",
+                   immediate_table
+               )),
+                &[],
+            )
+               .await
+               .context("while fetching payload from database")?
+                .iter() {
+                   let k = Self::Key::from_bytea(row.get::<_, Vec<u8>>(0));
+                   let epoch = row.get::<_, Epoch>(1);
+                    let v = row.get::<_, Option<Json<V>>>(2).map(|x| x.0);
+                    if let Some(v) = v {
+                        r.push((epoch, self.node_context(&k, s).await.unwrap() , v));
+                    }
+                }
+            Ok(r)
+        }
     }
 }
 
@@ -537,6 +549,55 @@ where
                 core_keys,
                 epoch_lineages,
             })
+        }
+    }
+
+    fn fetch_many_at<S: TreeStorage<Self>, I: IntoIterator<Item = (Epoch, Self::Key)> + Send>(
+        &self,
+        _s: &S,
+        db: DBPool,
+        table: &str,
+        data: I,
+    ) -> impl Future<Output = Result<Vec<(Epoch, NodeContext<Self::Key>, V)>>> + Send {
+        async move {
+            let data = data.into_iter().collect::<Vec<_>>();
+            let connection = db.get().await.unwrap();
+            let immediate_table = data
+                .iter()
+                .map(|(epoch, key)| {
+                    format!(
+                        "({epoch}::BIGINT, '\\x{}'::BYTEA)",
+                        hex::encode(key.to_bytea())
+                    )
+                })
+                .join(", ");
+
+            let mut r = Vec::new();
+            for row in connection
+            .query(
+                &dbg!(format!(
+                    "SELECT
+                       batch.key, batch.epoch, {table}.{PAYLOAD},
+                       {table}.{PARENT}, {table}.{LEFT_CHILD}, {table}.{RIGHT_CHILD}
+                     FROM
+                       (VALUES {}) AS batch (epoch, key)
+                     LEFT JOIN {table} ON
+                       batch.key = {table}.{KEY} AND {table}.{VALID_FROM} <= batch.epoch AND batch.epoch <= {table}.{VALID_UNTIL}",
+                   immediate_table
+               )),
+                &[],
+            )
+               .await
+               .context("while fetching payload from database")?
+                .iter() {
+                   let k = Self::Key::from_bytea(row.get::<_, Vec<u8>>(0));
+                   let epoch = row.get::<_, Epoch>(1);
+                    let v = row.get::<_, Option<Json<V>>>(2).map(|x| x.0);
+                    if let Some(v) = v {
+                        r.push((epoch, NodeContext{ node_id: k, parent: row.get::<_, Option<Vec<u8>>>(3).map(K::from_bytea), left: row.get::<_, Option<Vec<u8>>>(4).map(K::from_bytea), right: row.get::<_, Option<Vec<u8>>>(5).map(K::from_bytea) }, v));
+                    }
+                }
+            Ok(r)
         }
     }
 }
@@ -1004,16 +1065,6 @@ where
         }
     }
 
-    fn try_fetch_many_at<I: IntoIterator<Item = (Epoch, T::Key)> + Send>(
-        &self,
-        _data: I,
-    ) -> impl Future<Output = Result<Vec<Option<(Epoch, T::Key, T::Node)>>>> + Send
-    where
-        <I as IntoIterator>::IntoIter: Send,
-    {
-        async move { unimplemented!("should never be used") }
-    }
-
     async fn keys_at(&self, epoch: Epoch) -> Vec<T::Key> {
         let db = self.wrapped.lock().unwrap().db.clone();
         let table = self.wrapped.lock().unwrap().table.to_owned();
@@ -1130,19 +1181,6 @@ where
                 T::fetch_payload_at(db, &table, k, epoch).await.unwrap()
             }
         }
-    }
-
-    fn try_fetch_many_at<I: IntoIterator<Item = (Epoch, T::Key)> + Send>(
-        &self,
-        data: I,
-    ) -> impl Future<Output = Result<Vec<Option<(Epoch, T::Key, V)>>>> + Send
-    where
-        <I as IntoIterator>::IntoIter: Send,
-    {
-        trace!("[{self}] fetching many keys",);
-        let db = self.wrapped.lock().unwrap().db.clone();
-        let table = self.wrapped.lock().unwrap().table.to_owned();
-        async move { T::fetch_many_payload_at(db, &table, data).await }
     }
 
     async fn keys_at(&self, epoch: Epoch) -> Vec<T::Key> {

--- a/ryhope/src/storage/tests.rs
+++ b/ryhope/src/storage/tests.rs
@@ -1127,3 +1127,144 @@ WHERE {KEY} = ANY(ARRAY['\\x72657374657261'::bytea,'\\x706c7573'::bytea, '\\x636
         t.print();
     }
 }
+
+#[tokio::test]
+async fn all_pgsql() {
+    type K = String;
+    type V = usize;
+    type Tree = scapegoat::Tree<K>;
+    type Storage = PgsqlStorage<Tree, V>;
+
+    let mut s = MerkleTreeKvDb::<Tree, V, Storage>::new(
+        InitSettings::Reset(Tree::empty(Alpha::never_balanced())),
+        SqlStorageSettings {
+            source: SqlServerConnection::NewConnection(db_url()),
+            table: "fetch_all".to_string(),
+        },
+    )
+    .await
+    .unwrap();
+
+    const TEXT1: &str = "nature berce le il a froid";
+    const TEXT2: &str = "dort tranquille deux trous rouges cote";
+
+    s.in_transaction(|s| {
+        Box::pin(async {
+            for (i, word) in TEXT1.split(' ').enumerate() {
+                s.store(word.to_string(), i.try_into().unwrap()).await?;
+            }
+            Ok(())
+        })
+    })
+    .await
+    .unwrap();
+
+    s.in_transaction(|s| {
+        Box::pin(async {
+            s.remove("il".to_string()).await?;
+            s.remove("nature".to_string()).await?;
+            Ok(())
+        })
+    })
+    .await
+    .unwrap();
+
+    s.in_transaction(|s| {
+        Box::pin(async {
+            for (i, word) in TEXT2.split(' ').enumerate() {
+                s.store(word.to_string(), i.try_into().unwrap()).await?;
+            }
+            Ok(())
+        })
+    })
+    .await
+    .unwrap();
+
+    let pairs_1 = s.pairs_at(1).await.unwrap();
+    let pairs_2 = s.pairs_at(2).await.unwrap();
+    let pairs_3 = s.pairs_at(3).await.unwrap();
+
+    assert!(s.pairs_at(0).await.unwrap().is_empty());
+
+    assert!(!pairs_1.contains_key("tranquille"));
+    assert!(!pairs_1.contains_key("rouges"));
+    assert!(pairs_1.contains_key("nature"));
+    assert!(pairs_1.contains_key("froid"));
+
+    assert!(!pairs_2.contains_key("rouges"));
+    assert!(!pairs_2.contains_key("nature"));
+
+    assert!(pairs_3.contains_key("tranquille"));
+    assert!(pairs_3.contains_key("rouges"));
+    assert!(!pairs_3.contains_key("nature"));
+    assert!(pairs_3.contains_key("froid"));
+}
+
+#[tokio::test]
+async fn all_memory() {
+    type K = String;
+    type V = usize;
+    type Tree = scapegoat::Tree<K>;
+    type Storage = InMemory<Tree, V>;
+
+    let mut s = MerkleTreeKvDb::<Tree, V, Storage>::new(
+        InitSettings::Reset(Tree::empty(Alpha::never_balanced())),
+        (),
+    )
+    .await
+    .unwrap();
+
+    const TEXT1: &str = "nature berce le il a froid";
+    const TEXT2: &str = "dort tranquille deux trous rouges cote";
+
+    s.in_transaction(|s| {
+        Box::pin(async {
+            for (i, word) in TEXT1.split(' ').enumerate() {
+                s.store(word.to_string(), i.try_into().unwrap()).await?;
+            }
+            Ok(())
+        })
+    })
+    .await
+    .unwrap();
+
+    s.in_transaction(|s| {
+        Box::pin(async {
+            s.remove("il".to_string()).await?;
+            s.remove("nature".to_string()).await?;
+            Ok(())
+        })
+    })
+    .await
+    .unwrap();
+
+    s.in_transaction(|s| {
+        Box::pin(async {
+            for (i, word) in TEXT2.split(' ').enumerate() {
+                s.store(word.to_string(), i.try_into().unwrap()).await?;
+            }
+            Ok(())
+        })
+    })
+    .await
+    .unwrap();
+
+    let pairs_1 = s.pairs_at(1).await.unwrap();
+    let pairs_2 = s.pairs_at(2).await.unwrap();
+    let pairs_3 = s.pairs_at(3).await.unwrap();
+
+    assert!(s.pairs_at(0).await.unwrap().is_empty());
+
+    assert!(!pairs_1.contains_key("tranquille"));
+    assert!(!pairs_1.contains_key("rouges"));
+    assert!(pairs_1.contains_key("nature"));
+    assert!(pairs_1.contains_key("froid"));
+
+    assert!(!pairs_2.contains_key("rouges"));
+    assert!(!pairs_2.contains_key("nature"));
+
+    assert!(pairs_3.contains_key("tranquille"));
+    assert!(pairs_3.contains_key("rouges"));
+    assert!(!pairs_3.contains_key("nature"));
+    assert!(pairs_3.contains_key("froid"));
+}

--- a/ryhope/src/storage/tests.rs
+++ b/ryhope/src/storage/tests.rs
@@ -1051,18 +1051,16 @@ async fn fetch_many() {
         .await
         .unwrap()
         .into_iter()
+        .map(|(epoch, ctx, v)| (epoch, ctx.node_id, v))
         .collect::<HashSet<_>>();
 
     // using sets here, for PgSQL does not guarantee ordering
     assert_eq!(
         many,
         [
-            Some((1, "restera".to_string(), 12)),
-            Some((2, "restera".to_string(), 12)),
-            None,
-            Some((2, "car".to_string(), 0)),
-            None,
-            None
+            (1i64, "restera".to_string(), 12),
+            (2i64, "restera".to_string(), 12),
+            (2i64, "car".to_string(), 0),
         ]
         .into_iter()
         .collect::<HashSet<_>>()

--- a/ryhope/src/tree/mod.rs
+++ b/ryhope/src/tree/mod.rs
@@ -18,12 +18,12 @@ pub struct NodePath<K> {
 impl<K> NodePath<K> {
     /// Return an iterator over references to the keys forming the full path
     /// from the root to `target` (included).
-    pub fn full_path(&self) -> impl Iterator<Item = &K> {
+    pub fn full_path(&self) -> impl Iterator<Item = &K> + DoubleEndedIterator {
         self.ascendance.iter().chain(std::iter::once(&self.target))
     }
     /// Return an iterator over the keys forming the full path from the root to
     /// `target` (included).
-    pub fn into_full_path(self) -> impl Iterator<Item = K> {
+    pub fn into_full_path(self) -> impl Iterator<Item = K> + DoubleEndedIterator {
         self.ascendance
             .into_iter()
             .chain(std::iter::once(self.target))
@@ -148,7 +148,7 @@ pub trait MutableTree: TreeTopology {
 }
 
 /// A data structure encompassing the immediate neighborhood of a node.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct NodeContext<K> {
     /// The considered node ID
     pub node_id: K,

--- a/ryhope/src/tree/sbbst.rs
+++ b/ryhope/src/tree/sbbst.rs
@@ -214,11 +214,6 @@ impl State {
         }
     }
 
-    /// Return the largest value currently stored in the tree
-    fn outer_max(&self) -> NodeIdx {
-        self.outer_idx(self.inner_max())
-    }
-
     fn inner_max(&self) -> InnerIdx {
         self.max
     }


### PR DESCRIPTION
This PR implements the `try_fetch_many_at` and `pairs_at` functions, that allows respectively to simultaneously fetch the payloads of a set of `(epoch, key)` pairs, and `pairs_at`, that returns a hashmap of the active key/pair at a given epoch.