### PR TITLE
[WIP] fix (need more discussion): remove the input hash in groth16 inputs

### DIFF
--- a/gnark-utils/lib/circuit.go
+++ b/gnark-utils/lib/circuit.go
@@ -8,10 +8,10 @@ import (
 	"math/big"
 
 	"github.com/consensys/gnark/frontend"
+	gl "github.com/succinctlabs/gnark-plonky2-verifier/goldilocks"
 	"github.com/succinctlabs/gnark-plonky2-verifier/types"
 	"github.com/succinctlabs/gnark-plonky2-verifier/variables"
 	"github.com/succinctlabs/gnark-plonky2-verifier/verifier"
-	gl "github.com/succinctlabs/gnark-plonky2-verifier/goldilocks"
 )
 
 type VerifierCircuit struct {
@@ -19,7 +19,7 @@ type VerifierCircuit struct {
 	VerifierDigest frontend.Variable `gnark:"verifierDigest,public"`
 
 	// The input hash is the hash of all onchain inputs into the function.
-	InputHash frontend.Variable `gnark:"inputHash,public"`
+	InputHash frontend.Variable `gnark:"inputHash"`
 
 	// The output hash is the hash of all outputs from the function.
 	OutputHash frontend.Variable `gnark:"outputHash,public"`
@@ -72,35 +72,35 @@ func (c *VerifierCircuit) Define(api frontend.API) error {
 }
 
 // Build a `ProofWithPublicInputs` variable to be employed in `VerifierCircuit` to verify a proof for a circuit
-// with `commonCircuitData` 
+// with `commonCircuitData`
 func NewProofWithPublicInputs(commonCircuitData *types.CommonCircuitData) variables.ProofWithPublicInputs {
 	proof := newProof(commonCircuitData)
 	public_inputs := make([]gl.Variable, commonCircuitData.NumPublicInputs)
 	return variables.ProofWithPublicInputs{
-		Proof: proof,
+		Proof:        proof,
 		PublicInputs: public_inputs,
 	}
 }
 
-const SALT_SIZE = 4; // same as SALT_SIZE constant in Plonky2
+const SALT_SIZE = 4 // same as SALT_SIZE constant in Plonky2
 
 func newOpeningSet(commonCircuitData *types.CommonCircuitData) variables.OpeningSet {
-		constants := make([]gl.QuadraticExtensionVariable, commonCircuitData.NumConstants)
-		plonk_sigmas := make([]gl.QuadraticExtensionVariable, commonCircuitData.Config.NumRoutedWires)
-		wires := make([]gl.QuadraticExtensionVariable, commonCircuitData.Config.NumWires)
-		plonk_zs := make([]gl.QuadraticExtensionVariable, commonCircuitData.Config.NumChallenges)
-		plonk_zs_next := make([]gl.QuadraticExtensionVariable, commonCircuitData.Config.NumChallenges)
-		partial_products := make([]gl.QuadraticExtensionVariable, commonCircuitData.Config.NumChallenges * commonCircuitData.NumPartialProducts)
-		quotient_polys := make([]gl.QuadraticExtensionVariable, commonCircuitData.Config.NumChallenges * commonCircuitData.QuotientDegreeFactor)
-		return variables.OpeningSet{
-			Constants:       constants,
-			PlonkSigmas:     plonk_sigmas,
-			Wires:           wires,
-			PlonkZs:         plonk_zs,
-			PlonkZsNext:     plonk_zs_next,
-			PartialProducts: partial_products,
-			QuotientPolys:   quotient_polys,
-		}
+	constants := make([]gl.QuadraticExtensionVariable, commonCircuitData.NumConstants)
+	plonk_sigmas := make([]gl.QuadraticExtensionVariable, commonCircuitData.Config.NumRoutedWires)
+	wires := make([]gl.QuadraticExtensionVariable, commonCircuitData.Config.NumWires)
+	plonk_zs := make([]gl.QuadraticExtensionVariable, commonCircuitData.Config.NumChallenges)
+	plonk_zs_next := make([]gl.QuadraticExtensionVariable, commonCircuitData.Config.NumChallenges)
+	partial_products := make([]gl.QuadraticExtensionVariable, commonCircuitData.Config.NumChallenges*commonCircuitData.NumPartialProducts)
+	quotient_polys := make([]gl.QuadraticExtensionVariable, commonCircuitData.Config.NumChallenges*commonCircuitData.QuotientDegreeFactor)
+	return variables.OpeningSet{
+		Constants:       constants,
+		PlonkSigmas:     plonk_sigmas,
+		Wires:           wires,
+		PlonkZs:         plonk_zs,
+		PlonkZsNext:     plonk_zs_next,
+		PartialProducts: partial_products,
+		QuotientPolys:   quotient_polys,
+	}
 }
 
 func newFriQueryRound(commonCircuitData *types.CommonCircuitData) variables.FriQueryRound {
@@ -116,8 +116,8 @@ func newFriQueryRound(commonCircuitData *types.CommonCircuitData) variables.FriQ
 	num_leaves_per_oracle := [4]uint64{
 		commonCircuitData.NumConstants + commonCircuitData.Config.NumRoutedWires,
 		commonCircuitData.Config.NumWires + salt_size(),
-		commonCircuitData.Config.NumChallenges*(1 + commonCircuitData.NumPartialProducts) + salt_size(),
-		commonCircuitData.QuotientDegreeFactor* commonCircuitData.Config.NumChallenges + salt_size(),
+		commonCircuitData.Config.NumChallenges*(1+commonCircuitData.NumPartialProducts) + salt_size(),
+		commonCircuitData.QuotientDegreeFactor*commonCircuitData.Config.NumChallenges + salt_size(),
 	}
 	merkle_proof_len := params.LdeBits() - int(cap_height)
 	if merkle_proof_len < 0 {
@@ -127,9 +127,9 @@ func newFriQueryRound(commonCircuitData *types.CommonCircuitData) variables.FriQ
 	eval_proofs := make([]variables.FriEvalProof, len(num_leaves_per_oracle))
 	for j := 0; j < len(eval_proofs); j++ {
 		eval_proofs[j] = variables.NewFriEvalProof(
-				make([]gl.Variable, num_leaves_per_oracle[j]),
-				variables.NewFriMerkleProof(uint64(merkle_proof_len)),
-			)
+			make([]gl.Variable, num_leaves_per_oracle[j]),
+			variables.NewFriMerkleProof(uint64(merkle_proof_len)),
+		)
 	}
 	initial_trees := variables.NewFriInitialTreeProof(eval_proofs)
 	// build `FriQueryStep`
@@ -186,4 +186,3 @@ func newProof(commonCircuitData *types.CommonCircuitData) variables.Proof {
 		OpeningProof:              fri_proof,
 	}
 }
-

--- a/gnark-utils/lib/deserialize.go
+++ b/gnark-utils/lib/deserialize.go
@@ -3,6 +3,7 @@
 package main
 
 import "C"
+
 import (
 	"encoding/json"
 

--- a/gnark-utils/lib/lib.go
+++ b/gnark-utils/lib/lib.go
@@ -12,6 +12,7 @@ package main
    #include <stdlib.h>
 */
 import "C"
+
 import (
 	"bufio"
 	"bytes"
@@ -39,8 +40,10 @@ import (
 
 // Global variables for the proving process are only necessary to initialize
 // once by InitProver function.
-var R1CS constraint.ConstraintSystem
-var PK groth16.ProvingKey
+var (
+	R1CS constraint.ConstraintSystem
+	PK   groth16.ProvingKey
+)
 
 // Global variables for the verifying process are only necessary to initialize
 // once by InitVerifier function.
@@ -468,9 +471,9 @@ func ProveCircuit(
 	// We cut off the first 12 bytes because they encode length information.
 	publicWitnessBytes := rawPublicWitnessBytes[12:]
 
-	inputs := make([]string, 3)
+	inputs := make([]string, 2)
 	// Print out the public witness bytes.
-	for i := 0; i < 3; i++ {
+	for i := 0; i < 2; i++ {
 		inputs[i] = "0x" + hex.EncodeToString(publicWitnessBytes[i*fpSize:(i+1)*fpSize])
 	}
 

--- a/groth16-framework/src/proof.rs
+++ b/groth16-framework/src/proof.rs
@@ -8,7 +8,7 @@ pub struct Groth16Proof {
     /// The proofs item is an array of [U256; 8], which should be passed to the
     /// `verifyProof` function of the Solidity verifier contract.
     pub proofs: Vec<String>,
-    /// The inputs item is an array of [U256; 3], which should be passed to the
+    /// The inputs item is an array of [U256; 2], which should be passed to the
     /// `verifyProof` function of the Solidity verifier contract.
     pub inputs: Vec<String>,
     /// The original raw proof data is used to be verified off-chain.

--- a/groth16-framework/src/prover/groth16.rs
+++ b/groth16-framework/src/prover/groth16.rs
@@ -62,7 +62,7 @@ impl Groth16Prover {
     /// `groth16_proof.proofs + groth16_proof.inputs + plonky2_proof.public_inputs`.
     /// In the combined bytes, each part has number as:
     /// - groth16_proof.proofs: 8 * U256 = 256 bytes
-    /// - groth16_proof.inputs: 3 * U256 = 96 bytes
+    /// - groth16_proof.inputs: 2 * U256 = 64 bytes
     /// - plonky2_proof.public_inputs: the encoded public inputs exported by user
     pub fn prove(&self, plonky2_proof: &[u8]) -> Result<Vec<u8>> {
         // Deserialize the plonky2 proof.
@@ -112,7 +112,7 @@ fn load_circuit_data(asset_dir: &str) -> Result<CircuitData<F, C, D>> {
 /// `groth16_proof.proofs + groth16_proof.inputs + plonky2_proof.public_inputs`.
 /// In the combined bytes, each part has number as:
 /// - groth16_proof.proofs: 8 * U256 = 256 bytes
-/// - groth16_proof.inputs: 3 * U256 = 96 bytes
+/// - groth16_proof.inputs: 2 * U256 = 64 bytes
 /// - plonky2_proof.public_inputs: the encoded public inputs exported by user,
 ///   all fields must be in range of Uint32, it's restricted by `sha256` (in plonky2x).
 pub fn combine_proofs(

--- a/groth16-framework/test_data/Groth16VerifierExtensions.sol
+++ b/groth16-framework/test_data/Groth16VerifierExtensions.sol
@@ -94,10 +94,10 @@ contract Query is Verifier {
     }
 
     // The processQuery function does the followings:
-    // 1. Parse the Groth16 proofs (8 uint256) and inputs (3 uint256) from the `data`
+    // 1. Parse the Groth16 proofs (8 uint256) and inputs (2 uint256) from the `data`
     //    argument, and call `verifyProof` function for Groth16 verification.
     // 2. Calculate sha256 on the public inputs, and set the top 3 bits of this hash to 0.
-    //    Then ensure this hash value equals to the last Groth16 input (groth16_inputs[2]).
+    //    Then ensure this hash value equals to the last Groth16 input (groth16_inputs[1]).
     // 3. Parse the items from public inputs, and check as expected for query.
     // 4. Parse and return the query output from public inputs.
     function processQuery(
@@ -105,7 +105,7 @@ contract Query is Verifier {
         QueryInput memory query
     ) public view returns (QueryOutput memory) {
         // 1. Groth16 verification
-        uint256[3] memory groth16Inputs = verifyGroth16Proof(data);
+        uint256[2] memory groth16Inputs = verifyGroth16Proof(data);
 
         // 2. Ensure the sha256 of public inputs equals to the last Groth16 input.
         verifyPublicInputs(data, groth16Inputs);
@@ -122,12 +122,12 @@ contract Query is Verifier {
         bytes32[] calldata data
     ) internal view returns (uint256[3] memory) {
         uint256[8] memory proofs;
-        uint256[3] memory inputs;
+        uint256[2] memory inputs;
 
         for (uint32 i = 0; i < 8; ++i) {
             proofs[i] = uint256(data[i]);
         }
-        for (uint32 i = 0; i < 3; ++i) {
+        for (uint32 i = 0; i < 2; ++i) {
             inputs[i] = uint256(data[i + 8]);
         }
 
@@ -146,7 +146,7 @@ contract Query is Verifier {
     // Compute sha256 on the public inputs, and ensure it equals to the last Groth16 input.
     function verifyPublicInputs(
         bytes32[] calldata data,
-        uint256[3] memory groth16Inputs
+        uint256[2] memory groth16Inputs
     ) internal pure {
         // Parse the public inputs from calldata.
         bytes memory pi = parsePublicInputs(data);
@@ -158,7 +158,7 @@ contract Query is Verifier {
 
         // Require the sha256 equals to the last Groth16 input.
         require(
-            hash == groth16Inputs[2],
+            hash == groth16Inputs[1],
             "The sha256 hash of public inputs must be equal to the last of the Groth16 inputs"
         );
     }


### PR DESCRIPTION
May need more discussion.

### Summary

We have `3` Groth16 inputs for now:
- Index-0: circuit digest
- Index-1: input hash, it includes 32 bytes of `0`, since we don't really have `inputs`.
- Index-2: Output hash, we verify `sha256(plonky2_proof) == this_groth16_input`.

So I think we may remove this groth16 input (Uint256).