### PR TITLE
Feat/merkle path with successor gadget

### DIFF
--- a/mp2-common/src/u256.rs
+++ b/mp2-common/src/u256.rs
@@ -499,11 +499,9 @@ impl<F: SerializableRichField<D>, const D: usize> CircuitBuilderU256<F, D>
         left: &UInt256Target,
         right: &UInt256Target,
     ) -> BoolTarget {
-        // left <= right iff left - right requires a borrow or left - right == 0
-        let (res, borrow) = self.sub_u256(left, right);
-        let less_than = BoolTarget::new_unsafe(borrow.0);
-        let is_eq = self.is_zero(&res);
-        self.or(less_than, is_eq)
+        // left <= right iff ! right < left
+        let is_greater = self.is_less_than_u256(right, left);
+        self.not(is_greater)
     }
 
     fn is_zero(&mut self, target: &UInt256Target) -> BoolTarget {

--- a/verifiable-db/src/query/aggregation/mod.rs
+++ b/verifiable-db/src/query/aggregation/mod.rs
@@ -40,11 +40,9 @@ use super::{
     api::CircuitInput,
     computational_hash_ids::{ColumnIDs, Identifiers, PlaceholderIdentifier},
     universal_circuit::{
-        universal_circuit_inputs::{BasicOperation, PlaceholderId, Placeholders, ResultStructure},
-        universal_query_circuit::{
-            placeholder_hash, placeholder_hash_without_query_bounds, QueryBound,
-        },
-        ComputationalHash, PlaceholderHash,
+        universal_circuit_inputs::{BasicOperation, PlaceholderId, Placeholders, ResultStructure}, universal_query_circuit::{
+            placeholder_hash, placeholder_hash_without_query_bounds,
+        }, universal_query_gadget::QueryBound, ComputationalHash, PlaceholderHash
     },
 };
 

--- a/verifiable-db/src/query/aggregation/mod.rs
+++ b/verifiable-db/src/query/aggregation/mod.rs
@@ -40,9 +40,10 @@ use super::{
     api::CircuitInput,
     computational_hash_ids::{ColumnIDs, Identifiers, PlaceholderIdentifier},
     universal_circuit::{
-        universal_circuit_inputs::{BasicOperation, PlaceholderId, Placeholders, ResultStructure}, universal_query_circuit::{
-            placeholder_hash, placeholder_hash_without_query_bounds,
-        }, universal_query_gadget::QueryBound, ComputationalHash, PlaceholderHash
+        universal_circuit_inputs::{BasicOperation, PlaceholderId, Placeholders, ResultStructure},
+        universal_query_circuit::{placeholder_hash, placeholder_hash_without_query_bounds},
+        universal_query_gadget::QueryBound,
+        ComputationalHash, PlaceholderHash,
     },
 };
 

--- a/verifiable-db/src/query/aggregation/non_existence_inter.rs
+++ b/verifiable-db/src/query/aggregation/non_existence_inter.rs
@@ -3,7 +3,7 @@
 use crate::query::{
     aggregation::output_computation::compute_dummy_output_targets,
     public_inputs::PublicInputs,
-    universal_circuit::universal_query_circuit::{
+    universal_circuit::universal_query_gadget::{
         QueryBound, QueryBoundTarget, QueryBoundTargetInputs,
     },
 };

--- a/verifiable-db/src/query/api.rs
+++ b/verifiable-db/src/query/api.rs
@@ -40,9 +40,9 @@ use super::{
             BasicOperation, PlaceholderId, Placeholders, ResultStructure, RowCells,
         },
         universal_query_circuit::{
-            placeholder_hash, QueryBound, UniversalCircuitInput, UniversalQueryCircuitInputs,
+            placeholder_hash, UniversalCircuitInput, UniversalQueryCircuitInputs,
             UniversalQueryCircuitWires,
-        },
+        }, universal_query_gadget::QueryBound,
     },
     PI_LEN,
 };

--- a/verifiable-db/src/query/api.rs
+++ b/verifiable-db/src/query/api.rs
@@ -42,7 +42,8 @@ use super::{
         universal_query_circuit::{
             placeholder_hash, UniversalCircuitInput, UniversalQueryCircuitInputs,
             UniversalQueryCircuitWires,
-        }, universal_query_gadget::QueryBound,
+        },
+        universal_query_gadget::QueryBound,
     },
     PI_LEN,
 };

--- a/verifiable-db/src/query/computational_hash_ids.rs
+++ b/verifiable-db/src/query/computational_hash_ids.rs
@@ -36,7 +36,7 @@ use super::{
         universal_circuit_inputs::{
             BasicOperation, InputOperand, OutputItem, PlaceholderIdsSet, ResultStructure,
         },
-        universal_query_circuit::QueryBound,
+        universal_query_gadget::QueryBound,
         ComputationalHash, ComputationalHashTarget,
     },
 };
@@ -256,6 +256,10 @@ impl ColumnIDs {
             .into_iter()
             .chain(self.rest.clone())
             .collect_vec()
+    }
+
+    pub(crate) fn num_columns(&self) -> usize {
+        self.rest.len() + 2
     }
 }
 

--- a/verifiable-db/src/query/merkle_path.rs
+++ b/verifiable-db/src/query/merkle_path.rs
@@ -11,13 +11,13 @@ use mp2_common::{
     serialization::{
         deserialize_array, deserialize_long_array, serialize_array, serialize_long_array,
     },
-    types::HashOutput,
-    u256::{CircuitBuilderU256, UInt256Target, WitnessWriteU256},
-    utils::{Fieldable, SelectHashBuilder, ToTargets},
+    types::{CBuilder, HashOutput},
+    u256::{CircuitBuilderU256, UInt256Target, WitnessWriteU256, NUM_LIMBS},
+    utils::{Fieldable, FromTargets, SelectHashBuilder, ToTargets},
     D, F,
 };
 use plonky2::{
-    hash::hash_types::{HashOut, HashOutTarget},
+    hash::hash_types::{HashOut, HashOutTarget, NUM_HASH_OUT_ELTS},
     iop::{
         target::{BoolTarget, Target},
         witness::{PartialWitness, WitnessWrite},
@@ -26,7 +26,7 @@ use plonky2::{
 };
 use serde::{Deserialize, Serialize};
 
-use super::aggregation::{ChildPosition, NodeInfo};
+use super::aggregation::{ChildPosition, NodeInfo, NodeInfoTarget};
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 /// Input wires for Merkle path verification gadget
@@ -73,6 +73,33 @@ where
     )]
     is_real_node: [BoolTarget; MAX_DEPTH - 1],
 }
+#[derive(Clone, Debug)]
+/// Input wires related to the data of the end node whose membership is proven with `MerklePathWithNeighborsGadget`
+pub struct EndNodeInputs {
+    node_min: UInt256Target,
+    node_max: UInt256Target,
+    left_child_exists: BoolTarget,
+    left_child_info: NodeInfoTarget,
+    right_child_exists: BoolTarget,
+    right_child_info: NodeInfoTarget,
+}
+
+impl EndNodeInputs {
+    pub(crate) fn build(b: &mut CBuilder) -> Self {
+        let [node_min, node_max] = b.add_virtual_u256_arr_unsafe();
+        let [left_child_exists, right_child_exists] =
+            array::from_fn(|_| b.add_virtual_bool_target_safe());
+
+        Self {
+            node_min,
+            node_max,
+            left_child_exists,
+            left_child_info: NodeInfoTarget::build_unsafe(b),
+            right_child_exists,
+            right_child_info: NodeInfoTarget::build_unsafe(b),
+        }
+    }
+}
 
 #[derive(Clone, Debug)]
 /// Set of input/output wires built by merkle path verification gadget
@@ -83,6 +110,71 @@ where
     pub(crate) inputs: MerklePathTargetInputs<MAX_DEPTH>,
     /// Recomputed root for the Merkle path
     pub(crate) root: HashOutTarget,
+}
+#[derive(Clone, Debug)]
+/// Target containing data about a neighbor of a node (neighbor can be
+/// either the predecessor or the successor of a node)
+pub struct NeighborInfoTarget {
+    /// Boolean flag specifying whether the node has the given neighbor
+    is_found: BoolTarget,
+    /// Boolean flag specifying whether the neighbor is in the path from the
+    /// given node up to the root
+    is_in_path: BoolTarget,
+    /// Value of the neighbor (if the neighbor exists, otherwise a dummy value can be employed)
+    value: UInt256Target,
+    /// Hash of the neighbor node (if the neighbor exists, otherwise a dummy value can be employed)
+    hash: HashOutTarget,
+}
+
+impl NeighborInfoTarget {
+    const NUM_ELEMENTS: usize = 2 + NUM_LIMBS + NUM_HASH_OUT_ELTS;
+}
+
+impl ToTargets for NeighborInfoTarget {
+    fn to_targets(&self) -> Vec<Target> {
+        once(self.is_found.target)
+            .chain(once(self.is_in_path.target))
+            .chain(self.value.to_targets())
+            .chain(self.hash.to_targets())
+            .collect()
+    }
+}
+
+impl FromTargets for NeighborInfoTarget {
+    fn from_targets(t: &[Target]) -> Self {
+        Self {
+            is_found: BoolTarget::new_unsafe(t[0]),
+            is_in_path: BoolTarget::new_unsafe(t[1]),
+            value: UInt256Target::from_targets(&t[2..]),
+            hash: HashOutTarget::from_targets(&t[2 + NUM_LIMBS..]),
+        }
+    }
+}
+#[derive(Clone, Debug)]
+/// Set of input wires for the merkle path with neighbors gadget
+pub struct MerklePathWithNeighborsTargetInputs<const MAX_DEPTH: usize>
+where
+    [(); MAX_DEPTH - 1]:,
+{
+    pub(crate) path_inputs: MerklePathTargetInputs<MAX_DEPTH>,
+    pub(crate) end_node_inputs: EndNodeInputs,
+}
+
+#[derive(Clone, Debug)]
+/// Set of input/output wires built by merkle path with neighbors gadget
+pub struct MerklePathWithNeighborsTarget<const MAX_DEPTH: usize>
+where
+    [(); MAX_DEPTH - 1]:,
+{
+    pub(crate) inputs: MerklePathWithNeighborsTargetInputs<MAX_DEPTH>,
+    /// Recomputed root for the Merkle path
+    pub(crate) root: HashOutTarget,
+    /// Hash of the node at the end of the path
+    pub(crate) end_node_hash: HashOutTarget,
+    /// Info about the predecessor of the node at the end of the path
+    pub(crate) predecessor_info: NeighborInfoTarget,
+    /// Info about the successor of the node at the end of the path
+    pub(crate) successor_info: NeighborInfoTarget,
 }
 
 #[derive(Clone, Copy, Debug, Serialize, Deserialize)]
@@ -157,7 +249,6 @@ where
     pub fn new(
         path: &[(NodeInfo, ChildPosition)],
         siblings: &[Option<HashOutput>],
-        index_id: u64,
     ) -> Result<Self> {
         let num_real_nodes = path.len();
         ensure!(
@@ -204,54 +295,21 @@ where
         })
     }
 
-    /// Build wires for `MerklePathGadget`. The requrested inputs are:
-    /// - `start_node`: The hash of the first node in the path
+    /// Build wires for `MerklePathGadget`. The required inputs are:
+    /// - `end_node`: The hash of the first node in the path
     /// - `index_id`: Integer identifier of the index column to be placed in the hash
     ///     of the nodes of the path
     pub fn build(
         b: &mut CircuitBuilder<F, D>,
-        start_node: HashOutTarget,
+        end_node: HashOutTarget,
         index_id: Target,
     ) -> MerklePathTarget<MAX_DEPTH> {
-        let is_left_child = array::from_fn(|_| b.add_virtual_bool_target_unsafe());
-        let [sibling_hash, embedded_tree_hash] =
-            [0, 1].map(|_| array::from_fn(|_| b.add_virtual_hash()));
-        let [node_min, node_max, node_value] = [0, 1, 2].map(
-            |_| b.add_virtual_u256_arr_unsafe(), // unsafe should be ok since we just need to hash them
-        );
-        let is_real_node = array::from_fn(|_| b.add_virtual_bool_target_safe());
-
-        let mut final_hash = start_node;
-        for i in 0..MAX_DEPTH - 1 {
-            let rest = node_min[i]
-                .to_targets()
-                .into_iter()
-                .chain(node_max[i].to_targets())
-                .chain(once(index_id))
-                .chain(node_value[i].to_targets())
-                .chain(embedded_tree_hash[i].to_targets())
-                .collect_vec();
-            let node_hash = HashOutTarget::from_vec(hash_maybe_first(
-                b,
-                is_left_child[i],
-                sibling_hash[i].elements,
-                final_hash.elements,
-                rest.as_slice(),
-            ));
-            final_hash = b.select_hash(is_real_node[i], &node_hash, &final_hash);
-        }
-
-        MerklePathTarget {
-            inputs: MerklePathTargetInputs {
-                is_left_child,
-                sibling_hash,
-                node_min,
-                node_max,
-                node_value,
-                embedded_tree_hash,
-                is_real_node,
-            },
-            root: final_hash,
+        if let MerklePathWires::MerklePath(out_targets) =
+            build_common(b, end_node, index_id, false, None)
+        {
+            out_targets
+        } else {
+            unreachable!()
         }
     }
 
@@ -291,29 +349,336 @@ where
     }
 }
 
+#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
+pub struct MerklePathWithNeighborsGadget<const MAX_DEPTH: usize>
+where
+    [(); MAX_DEPTH - 1]:,
+{
+    path_gadget: MerklePathGadget<MAX_DEPTH>,
+    end_node_min: U256,
+    end_node_max: U256,
+    end_node_children: [Option<NodeInfo>; 2],
+}
+
+impl<const MAX_DEPTH: usize> MerklePathWithNeighborsGadget<MAX_DEPTH>
+where
+    [(); MAX_DEPTH - 1]:,
+{
+    /// Build a new instance of `Self`, representing the path from `end_node` to the root.
+    /// Such path is provided as input, altogether with the siblings of the nodes in such
+    /// path, if any. The method requires also the data about the children of `end_node`,
+    /// if any.
+    pub fn new(
+        path: &[(NodeInfo, ChildPosition)],
+        siblings: &[Option<HashOutput>],
+        end_node: &NodeInfo,
+        end_node_children: [Option<NodeInfo>; 2],
+    ) -> Result<Self> {
+        let path_gadget = MerklePathGadget::new(path, siblings)?;
+        Ok(Self {
+            path_gadget,
+            end_node_min: end_node.min,
+            end_node_max: end_node.max,
+            end_node_children,
+        })
+    }
+
+    /// Build wires for `MerklePathGadget`. The required inputs are:
+    /// - `end_node_value`: Value stored in the first node in the path
+    /// - `end_node_tree_hash` : Hash of the embedded tree stored in the first node in the path
+    /// - `index_id`: Integer identifier of the index column to be placed in the hash
+    ///     of the nodes of the path
+    pub fn build(
+        b: &mut CircuitBuilder<F, D>,
+        end_node_value: UInt256Target,
+        end_node_tree_hash: HashOutTarget,
+        index_id: Target,
+    ) -> MerklePathWithNeighborsTarget<MAX_DEPTH> {
+        let end_node_info = EndNodeInputs::build(b);
+        // compute end node hash
+        let left_child_hash = end_node_info.left_child_info.compute_node_hash(b, index_id);
+        let right_child_hash = end_node_info
+            .right_child_info
+            .compute_node_hash(b, index_id);
+        let empty_hash = b.constant_hash(*empty_poseidon_hash());
+        let left_child_hash = b.select_hash(
+            end_node_info.left_child_exists,
+            &left_child_hash,
+            &empty_hash,
+        );
+        let right_child_hash = b.select_hash(
+            end_node_info.right_child_exists,
+            &right_child_hash,
+            &empty_hash,
+        );
+        let end_node = NodeInfoTarget {
+            embedded_tree_hash: end_node_tree_hash,
+            child_hashes: [left_child_hash, right_child_hash],
+            value: end_node_value,
+            min: end_node_info.node_min.clone(),
+            max: end_node_info.node_max.clone(),
+        };
+        let end_node_hash = end_node.compute_node_hash(b, index_id);
+        if let MerklePathWires::MerklePathWithNeighbors(out_targets) =
+            build_common(b, end_node_hash, index_id, true, Some(end_node_info))
+        {
+            out_targets
+        } else {
+            unreachable!()
+        }
+    }
+
+    pub fn assign(
+        &self,
+        pw: &mut PartialWitness<F>,
+        wires: &MerklePathWithNeighborsTargetInputs<MAX_DEPTH>,
+    ) {
+        self.path_gadget.assign(pw, &wires.path_inputs);
+        pw.set_u256_target_arr(
+            &[
+                wires.end_node_inputs.node_min.clone(),
+                wires.end_node_inputs.node_max.clone(),
+            ],
+            &[self.end_node_min, self.end_node_max],
+        );
+        pw.set_bool_target(
+            wires.end_node_inputs.left_child_exists,
+            self.end_node_children[0].is_some(),
+        );
+        pw.set_bool_target(
+            wires.end_node_inputs.right_child_exists,
+            self.end_node_children[1].is_some(),
+        );
+        let left_child_info = self.end_node_children[0].unwrap_or_default();
+        let right_child_info = self.end_node_children[1].unwrap_or_default();
+        wires
+            .end_node_inputs
+            .left_child_info
+            .set_target(pw, &left_child_info);
+        wires
+            .end_node_inputs
+            .right_child_info
+            .set_target(pw, &right_child_info);
+    }
+}
+
+#[derive(Clone, Debug)]
+/// Enum employed as output type for `build_common` method, which allows to implement the core logic
+/// of `MerklePathGadget` and `MerklePathGadgetWithNeighbors` in a single method, hence avoiding
+/// code duplication
+enum MerklePathWires<const MAX_DEPTH: usize>
+where
+    [(); MAX_DEPTH - 1]:,
+{
+    MerklePath(MerklePathTarget<MAX_DEPTH>),
+    MerklePathWithNeighbors(MerklePathWithNeighborsTarget<MAX_DEPTH>),
+}
+
+/// Build `MerklePathWires`, building `MerklePathWithNeighborsTarget` if the input flag `with_neighbors`
+/// is true, building `MerkelPathTarget` otherwise. The required inputs are:
+/// - `end_node`: The hash of the first node in the path
+/// - `index_id`: Integer identifier of the index column to be placed in the hash
+///     of the nodes of the path
+/// - `end_node_info` : Data about `end_node`; must be provided only if `with_neighbors == true`
+fn build_common<const MAX_DEPTH: usize>(
+    b: &mut CircuitBuilder<F, D>,
+    end_node: HashOutTarget,
+    index_id: Target,
+    with_neighbors: bool,
+    end_node_info: Option<EndNodeInputs>,
+) -> MerklePathWires<MAX_DEPTH>
+where
+    [(); MAX_DEPTH - 1]:,
+{
+    let is_left_child = array::from_fn(|_| b.add_virtual_bool_target_unsafe());
+    let [sibling_hash, embedded_tree_hash] =
+        [0, 1].map(|_| array::from_fn(|_| b.add_virtual_hash()));
+    let [node_min, node_max, node_value] = [0, 1, 2].map(
+        |_| b.add_virtual_u256_arr_unsafe(), // unsafe should be ok since we just need to hash them
+    );
+    let is_real_node = array::from_fn(|_| b.add_virtual_bool_target_safe());
+
+    let (mut predecessor_info, mut successor_info) = if with_neighbors {
+        // we need to initialize predecessor and successor data
+        let end_node_info = end_node_info.as_ref().unwrap();
+        // the predecessor of end_node is an ancestor of end_node iff end_node has no left child
+        let is_predecessor_in_path = b.not(end_node_info.left_child_exists);
+        let zero_u256 = b.zero_u256();
+        // Initialize value of predecessor node of end_node to a dummy value if the predecessor node
+        // will be found in the path; otherwise, the predecessor_value is the maximum value in
+        // the subtree rooted in the left child of end_node
+        let predecessor_value = b.select_u256(
+            is_predecessor_in_path,
+            &zero_u256,
+            &end_node_info.left_child_info.max,
+        );
+        // the predecessor value is already found if end_node has a left child
+        let predecessor_found = end_node_info.left_child_exists;
+        // Initialize predecessor node hash to a dummy value
+        let predecessor_hash = b.constant_hash(*empty_poseidon_hash());
+        // build predecessor info
+        let predecessor_info = NeighborInfoTarget {
+            is_found: predecessor_found,
+            is_in_path: is_predecessor_in_path,
+            value: predecessor_value,
+            hash: predecessor_hash,
+        };
+
+        // the successor of end_node is an ancestor of end_node iff end_node has no right child
+        let is_successor_in_path = b.not(end_node_info.right_child_exists);
+        // Initialize value of successor node of end_node to a dummy value if the successor node
+        // will be found in the path; otherwise, successor_value is the minimum value in
+        // the subtree rooted in the right child of end_node
+        let successor_value = b.select_u256(
+            is_successor_in_path,
+            &zero_u256,
+            &end_node_info.right_child_info.min,
+        );
+        // the successor value is already found if end_node has a right child
+        let successor_found = end_node_info.right_child_exists;
+        // Initialize successor node hash to a dummy value
+        let successor_hash = b.constant_hash(*empty_poseidon_hash());
+        // build successor info
+        let successor_info = NeighborInfoTarget {
+            is_found: successor_found,
+            is_in_path: is_successor_in_path,
+            value: successor_value,
+            hash: successor_hash,
+        };
+        (Some(predecessor_info), Some(successor_info))
+    } else {
+        (None, None)
+    };
+
+    let mut final_hash = end_node;
+    for i in 0..MAX_DEPTH - 1 {
+        let rest = node_min[i]
+            .to_targets()
+            .into_iter()
+            .chain(node_max[i].to_targets())
+            .chain(once(index_id))
+            .chain(node_value[i].to_targets())
+            .chain(embedded_tree_hash[i].to_targets())
+            .collect_vec();
+        let node_hash = HashOutTarget::from_vec(hash_maybe_first(
+            b,
+            is_left_child[i],
+            sibling_hash[i].elements,
+            final_hash.elements,
+            rest.as_slice(),
+        ));
+        final_hash = b.select_hash(is_real_node[i], &node_hash, &final_hash);
+        if let Some(predecessor_info) = predecessor_info.as_mut() {
+            // we need also to look for the predecessor
+            let is_right_child = b.not(is_left_child[i]);
+            /* First, we determine if the current node is the predecessor */
+            let mut is_current_node_predecessor = b.not(predecessor_info.is_found); // current node cannot
+                                                                                    // be the predecessor if predecessor has already been found
+            is_current_node_predecessor = b.and(is_current_node_predecessor, is_real_node[i]); // current node
+                                                                                               // cannot be the predecessor if it's not a real node
+            is_current_node_predecessor = b.and(is_current_node_predecessor, is_right_child); // current node
+                                                                                              // is the predecessor if the previous node in the path is its right child
+                                                                                              // we update predecessor_info.hash if current node is the predecessor
+            predecessor_info.hash = b.select_hash(
+                is_current_node_predecessor,
+                &node_hash,
+                &predecessor_info.hash,
+            );
+            // we update predecessor_info.value if current node is the predecessor
+            predecessor_info.value = b.select_u256(
+                is_current_node_predecessor,
+                &node_value[i],
+                &predecessor_info.value,
+            );
+            // set predecessor_info.is_found if current node is the predecessor
+            predecessor_info.is_found =
+                b.or(predecessor_info.is_found, is_current_node_predecessor);
+        }
+        if let Some(successor_info) = successor_info.as_mut() {
+            // we need also to look for the successor
+            /* First, we determine if the current node is the successor */
+            let mut is_current_node_successor = b.not(successor_info.is_found); // current node cannot
+                                                                                // be the successor if successor has already been found
+            is_current_node_successor = b.and(is_current_node_successor, is_real_node[i]); // current node
+                                                                                           // cannot be the successor if it's not a real node
+            is_current_node_successor = b.and(is_current_node_successor, is_left_child[i]); // current node
+                                                                                            // is the successor if the previous node in the path is its left child
+                                                                                            // we update successor_info.hash if current node is the successor
+            successor_info.hash =
+                b.select_hash(is_current_node_successor, &node_hash, &successor_info.hash);
+            // we update successor_info.value if current node is the successor
+            successor_info.value = b.select_u256(
+                is_current_node_successor,
+                &node_value[i],
+                &successor_info.value,
+            );
+            // set successor_info.is_found if current node is the successor
+            successor_info.is_found = b.or(successor_info.is_found, is_current_node_successor);
+        }
+    }
+    let inputs = MerklePathTargetInputs {
+        is_left_child,
+        sibling_hash,
+        node_min,
+        node_max,
+        node_value,
+        embedded_tree_hash,
+        is_real_node,
+    };
+    if with_neighbors {
+        MerklePathWires::MerklePathWithNeighbors(MerklePathWithNeighborsTarget {
+            inputs: MerklePathWithNeighborsTargetInputs {
+                path_inputs: inputs,
+                end_node_inputs: end_node_info.unwrap(),
+            },
+            root: final_hash,
+            end_node_hash: end_node,
+            predecessor_info: predecessor_info.unwrap(),
+            successor_info: successor_info.unwrap(),
+        })
+    } else {
+        MerklePathWires::MerklePath(MerklePathTarget {
+            inputs,
+            root: final_hash,
+        })
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::array;
 
-    use mp2_common::{types::HashOutput, utils::ToTargets, C, D, F};
+    use alloy::primitives::U256;
+    use mp2_common::{
+        poseidon::empty_poseidon_hash,
+        types::HashOutput,
+        u256::{CircuitBuilderU256, UInt256Target, WitnessWriteU256, NUM_LIMBS},
+        utils::{FromFields, ToTargets, TryIntoBool},
+        C, D, F,
+    };
     use mp2_test::{
         circuit::{run_circuit, UserCircuit},
         utils::{gen_random_field_hash, gen_random_u256},
     };
     use plonky2::{
         field::types::{PrimeField64, Sample},
-        hash::hash_types::{HashOut, HashOutTarget},
+        hash::hash_types::{HashOut, HashOutTarget, NUM_HASH_OUT_ELTS},
         iop::{
             target::Target,
             witness::{PartialWitness, WitnessWrite},
         },
-        plonk::{circuit_builder::CircuitBuilder, config::GenericHashOut},
+        plonk::{
+            circuit_builder::CircuitBuilder, config::GenericHashOut, proof::ProofWithPublicInputs,
+        },
     };
     use rand::thread_rng;
 
     use crate::query::aggregation::{ChildPosition, NodeInfo};
 
-    use super::{MerklePathGadget, MerklePathTargetInputs};
+    use super::{
+        MerklePathGadget, MerklePathTargetInputs, MerklePathWithNeighborsGadget,
+        MerklePathWithNeighborsTargetInputs, NeighborInfoTarget,
+    };
 
     #[derive(Clone, Debug)]
     struct TestMerklePathGadget<const MAX_DEPTH: usize>
@@ -321,7 +686,7 @@ mod tests {
         [(); MAX_DEPTH - 1]:,
     {
         merkle_path_inputs: MerklePathGadget<MAX_DEPTH>,
-        start_node: NodeInfo,
+        end_node: NodeInfo,
         index_id: F,
     }
 
@@ -333,42 +698,142 @@ mod tests {
 
         fn build(c: &mut CircuitBuilder<F, D>) -> Self::Wires {
             let index_id = c.add_virtual_target();
-            let start_node = c.add_virtual_hash();
-            let merkle_path_wires = MerklePathGadget::build(c, start_node, index_id);
+            let end_node = c.add_virtual_hash();
+            let merkle_path_wires = MerklePathGadget::build(c, end_node, index_id);
 
             c.register_public_inputs(&merkle_path_wires.root.to_targets());
 
-            (merkle_path_wires.inputs, start_node, index_id)
+            (merkle_path_wires.inputs, end_node, index_id)
         }
 
         fn prove(&self, pw: &mut PartialWitness<F>, wires: &Self::Wires) {
             self.merkle_path_inputs.assign(pw, &wires.0);
-            pw.set_hash_target(wires.1, self.start_node.compute_node_hash(self.index_id));
+            pw.set_hash_target(wires.1, self.end_node.compute_node_hash(self.index_id));
             pw.set_target(wires.2, self.index_id);
         }
     }
 
-    #[test]
-    fn test_merkle_path() {
-        // Test a Merkle-path on the following Merkle-tree
-        //              A
-        //          B       C
-        //      D               G
-        //   E      F
+    #[derive(Clone, Debug, Eq, PartialEq)]
+    pub(crate) struct NeighborInfo {
+        is_found: bool,
+        is_in_path: bool,
+        value: U256,
+        hash: HashOut<F>,
+    }
 
-        // first, build the Merkle-tree
+    impl FromFields<F> for NeighborInfo {
+        fn from_fields(t: &[F]) -> Self {
+            assert!(t.len() >= NeighborInfoTarget::NUM_ELEMENTS);
+            Self {
+                is_found: t[0].try_into_bool().unwrap(),
+                is_in_path: t[1].try_into_bool().unwrap(),
+                value: U256::from_fields(&t[2..2 + NUM_LIMBS]),
+                hash: HashOut::from_vec(
+                    t[2 + NUM_LIMBS..NeighborInfoTarget::NUM_ELEMENTS].to_vec(),
+                ),
+            }
+        }
+    }
+
+    impl NeighborInfo {
+        pub(crate) fn assign(&self, pw: &mut PartialWitness<F>, wires: &NeighborInfoTarget) {
+            [
+                (wires.is_found, self.is_found),
+                (wires.is_in_path, self.is_in_path),
+            ]
+            .into_iter()
+            .for_each(|(target, value)| pw.set_bool_target(target, value));
+            pw.set_u256_target(&wires.value, self.value);
+            pw.set_hash_target(wires.hash, self.hash);
+        }
+    }
+
+    #[derive(Clone, Debug)]
+    struct TestMerklePathWithNeighborsGadget<const MAX_DEPTH: usize>
+    where
+        [(); MAX_DEPTH - 1]:,
+    {
+        merkle_path_inputs: MerklePathWithNeighborsGadget<MAX_DEPTH>,
+        end_node: NodeInfo,
+        index_id: F,
+    }
+
+    impl<const MAX_DEPTH: usize> UserCircuit<F, D> for TestMerklePathWithNeighborsGadget<MAX_DEPTH>
+    where
+        [(); MAX_DEPTH - 1]:,
+    {
+        type Wires = (
+            MerklePathWithNeighborsTargetInputs<MAX_DEPTH>,
+            HashOutTarget,
+            UInt256Target,
+            Target,
+        );
+
+        fn build(c: &mut CircuitBuilder<F, D>) -> Self::Wires {
+            let index_id = c.add_virtual_target();
+            let end_node_tree_hash = c.add_virtual_hash();
+            let end_node_value = c.add_virtual_u256_unsafe();
+            let merkle_path_wires = MerklePathWithNeighborsGadget::build(
+                c,
+                end_node_value.clone(),
+                end_node_tree_hash,
+                index_id,
+            );
+
+            c.register_public_inputs(&merkle_path_wires.root.to_targets());
+            c.register_public_inputs(&merkle_path_wires.end_node_hash.to_targets());
+            c.register_public_inputs(&merkle_path_wires.predecessor_info.to_targets());
+            c.register_public_inputs(&merkle_path_wires.successor_info.to_targets());
+
+            (
+                merkle_path_wires.inputs,
+                end_node_tree_hash,
+                end_node_value,
+                index_id,
+            )
+        }
+
+        fn prove(&self, pw: &mut PartialWitness<F>, wires: &Self::Wires) {
+            self.merkle_path_inputs.assign(pw, &wires.0);
+            pw.set_hash_target(wires.1, self.end_node.embedded_tree_hash);
+            pw.set_u256_target(&wires.2, self.end_node.value);
+            pw.set_target(wires.3, self.index_id);
+        }
+    }
+    // Build the following Merkle-tree to be employed in tests, using
+    // the `index_id` provided as input to compute the hash of the nodes
+    //              A
+    //          B       C
+    //      D               G
+    //   E      F
+    fn generate_test_tree(index_id: F) -> [NodeInfo; 7] {
         let rng = &mut thread_rng();
-        let index_id = F::rand();
         // closure to generate a random node of the tree from the 2 children, if any
         let mut random_node =
-            |left_child: Option<&HashOutput>, right_child: Option<&HashOutput>| -> NodeInfo {
+            |left_child: Option<&NodeInfo>, right_child: Option<&NodeInfo>| -> NodeInfo {
                 let embedded_tree_hash =
                     HashOutput::try_from(gen_random_field_hash::<F>().to_bytes()).unwrap();
-                let [node_min, node_max, node_value] = array::from_fn(|_| gen_random_u256(rng));
+                let node_value = gen_random_u256(rng);
+                let node_min = if let Some(node) = &left_child {
+                    node.min
+                } else {
+                    node_value
+                };
+                let node_max = if let Some(node) = &right_child {
+                    node.max
+                } else {
+                    node_value
+                };
+                let left_child = left_child.map(|node| {
+                    HashOutput::try_from(node.compute_node_hash(index_id).to_bytes()).unwrap()
+                });
+                let right_child = right_child.map(|node| {
+                    HashOutput::try_from(node.compute_node_hash(index_id).to_bytes()).unwrap()
+                });
                 NodeInfo::new(
                     &embedded_tree_hash,
-                    left_child,
-                    right_child,
+                    left_child.as_ref(),
+                    right_child.as_ref(),
                     node_value,
                     node_min,
                     node_max,
@@ -378,27 +843,19 @@ mod tests {
         let node_E = random_node(None, None); // it's a leaf node, so no children
         let node_F = random_node(None, None);
         let node_G = random_node(None, None);
-        let node_E_hash =
-            HashOutput::try_from(node_E.compute_node_hash(index_id).to_bytes()).unwrap();
-        let node_D = random_node(
-            Some(&node_E_hash),
-            Some(&HashOutput::try_from(node_F.compute_node_hash(index_id).to_bytes()).unwrap()),
-        );
-        let node_B = random_node(
-            Some(&HashOutput::try_from(node_D.compute_node_hash(index_id).to_bytes()).unwrap()),
-            None,
-        );
-        let node_C = random_node(
-            None,
-            Some(&HashOutput::try_from(node_G.compute_node_hash(index_id).to_bytes()).unwrap()),
-        );
-        let node_B_hash =
-            HashOutput::try_from(node_B.compute_node_hash(index_id).to_bytes()).unwrap();
-        let node_C_hash =
-            HashOutput::try_from(node_C.compute_node_hash(index_id).to_bytes()).unwrap();
-        let node_A = random_node(Some(&node_B_hash), Some(&node_C_hash));
-        let root = node_A.compute_node_hash(index_id);
+        let node_D = random_node(Some(&node_E), Some(&node_F));
+        let node_B = random_node(Some(&node_D), None);
+        let node_C = random_node(None, Some(&node_G));
+        let node_A = random_node(Some(&node_B), Some(&node_C));
+        [node_A, node_B, node_C, node_D, node_E, node_F, node_G]
+    }
 
+    #[test]
+    fn test_merkle_path() {
+        // first, build the Merkle-tree
+        let index_id = F::rand();
+        let [node_A, node_B, node_C, node_D, node_E, node_F, node_G] = generate_test_tree(index_id);
+        let root = node_A.compute_node_hash(index_id);
         // verify Merkle-path related to leaf F
         const MAX_DEPTH: usize = 10;
         let path = vec![
@@ -406,14 +863,14 @@ mod tests {
             (node_B.clone(), ChildPosition::Left),
             (node_A.clone(), ChildPosition::Left),
         ];
+        let node_E_hash = HashOutput::try_from(node_E.compute_node_hash(index_id)).unwrap();
+        let node_C_hash = HashOutput::try_from(node_C.compute_node_hash(index_id)).unwrap();
         let siblings = vec![Some(node_E_hash), None, Some(node_C_hash.clone())];
-        let merkle_path_inputs =
-            MerklePathGadget::<MAX_DEPTH>::new(&path, &siblings, index_id.to_canonical_u64())
-                .unwrap();
+        let merkle_path_inputs = MerklePathGadget::<MAX_DEPTH>::new(&path, &siblings).unwrap();
 
         let circuit = TestMerklePathGadget::<MAX_DEPTH> {
             merkle_path_inputs,
-            start_node: node_F.clone(),
+            end_node: node_F.clone(),
             index_id,
         };
 
@@ -426,13 +883,12 @@ mod tests {
             (node_C.clone(), ChildPosition::Right),
             (node_A.clone(), ChildPosition::Right),
         ];
+        let node_B_hash = HashOutput::try_from(node_B.compute_node_hash(index_id)).unwrap();
         let siblings = vec![None, Some(node_B_hash)];
-        let merkle_path_inputs =
-            MerklePathGadget::<MAX_DEPTH>::new(&path, &siblings, index_id.to_canonical_u64())
-                .unwrap();
+        let merkle_path_inputs = MerklePathGadget::<MAX_DEPTH>::new(&path, &siblings).unwrap();
         let circuit = TestMerklePathGadget::<MAX_DEPTH> {
             merkle_path_inputs,
-            start_node: node_G.clone(),
+            end_node: node_G.clone(),
             index_id,
         };
 
@@ -446,17 +902,296 @@ mod tests {
             (node_A.clone(), ChildPosition::Left),
         ];
         let siblings = vec![None, Some(node_C_hash)];
-        let merkle_path_inputs =
-            MerklePathGadget::<MAX_DEPTH>::new(&path, &siblings, index_id.to_canonical_u64())
-                .unwrap();
+        let merkle_path_inputs = MerklePathGadget::<MAX_DEPTH>::new(&path, &siblings).unwrap();
         let circuit = TestMerklePathGadget::<MAX_DEPTH> {
             merkle_path_inputs,
-            start_node: node_D.clone(),
+            end_node: node_D.clone(),
             index_id,
         };
 
         let proof = run_circuit::<F, D, C, _>(circuit);
         // check that the re-computed root is correct
         assert_eq!(proof.public_inputs, root.to_vec());
+    }
+
+    #[test]
+    fn test_merkle_path_with_neighbors() {
+        // first, build the Merkle-tree
+        let index_id = F::rand();
+        let [node_A, node_B, node_C, node_D, node_E, node_F, node_G] = generate_test_tree(index_id);
+        let root = node_A.compute_node_hash(index_id);
+        // verify Merkle-path related to leaf F
+        const MAX_DEPTH: usize = 10;
+        let path = vec![
+            (node_D.clone(), ChildPosition::Right), // we start from the ancestor of the start node of the path
+            (node_B.clone(), ChildPosition::Left),
+            (node_A.clone(), ChildPosition::Left),
+        ];
+        let node_E_hash = HashOutput::try_from(node_E.compute_node_hash(index_id)).unwrap();
+        let node_C_hash = HashOutput::try_from(node_C.compute_node_hash(index_id)).unwrap();
+        let siblings = vec![Some(node_E_hash), None, Some(node_C_hash.clone())];
+        let merkle_path_inputs = MerklePathWithNeighborsGadget::<MAX_DEPTH>::new(
+            &path,
+            &siblings,
+            &node_F,
+            [None, None], // it's a leaf node
+        )
+        .unwrap();
+
+        let circuit = TestMerklePathWithNeighborsGadget::<MAX_DEPTH> {
+            merkle_path_inputs,
+            end_node: node_F.clone(),
+            index_id,
+        };
+
+        let proof = run_circuit(circuit);
+
+        // closure to check correctness of public inputs
+        let check_public_inputs = |proof: ProofWithPublicInputs<F, C, D>,
+                                   node: &NodeInfo,
+                                   node_name: &str,
+                                   predecessor_info,
+                                   successor_info| {
+            // check that the re-computed root is correct
+            assert_eq!(
+                proof.public_inputs[..NUM_HASH_OUT_ELTS],
+                root.to_vec(),
+                "failed for node {node_name}"
+            );
+            // check that the hash of node_F is correct
+            let node_hash = node.compute_node_hash(index_id);
+            assert_eq!(
+                proof.public_inputs[NUM_HASH_OUT_ELTS..2 * NUM_HASH_OUT_ELTS],
+                node_hash.elements,
+                "failed for node {node_name}"
+            );
+            // check predecessor info extracted in the circuit
+            assert_eq!(
+                NeighborInfo::from_fields(&proof.public_inputs[2 * NUM_HASH_OUT_ELTS..]),
+                predecessor_info,
+                "failed for node {node_name}"
+            );
+            // check successor info extracted in the circuit
+            assert_eq!(
+                NeighborInfo::from_fields(
+                    &proof.public_inputs
+                        [2 * NUM_HASH_OUT_ELTS + NeighborInfoTarget::NUM_ELEMENTS..]
+                ),
+                successor_info,
+                "failed for node {node_name}"
+            );
+        };
+        // build predecessor and successor info for node_F
+        // predecessor should be node_D
+        let node_D_hash = node_D.compute_node_hash(index_id);
+        let predecessor_info = NeighborInfo {
+            is_found: true,
+            is_in_path: true,
+            value: node_D.value,
+            hash: node_D_hash,
+        };
+        // successor should be node_B
+        let node_B_hash = node_B.compute_node_hash(index_id);
+        let successor_info = NeighborInfo {
+            is_found: true,
+            is_in_path: true,
+            value: node_B.value,
+            hash: node_B_hash,
+        };
+        check_public_inputs(proof, &node_F, "node F", predecessor_info, successor_info);
+
+        // verify Merkle-path related to leaf E
+        let path = vec![
+            (node_D.clone(), ChildPosition::Left), // we start from the ancestor of the start node of the path
+            (node_B.clone(), ChildPosition::Left),
+            (node_A.clone(), ChildPosition::Left),
+        ];
+        let node_F_hash = HashOutput::try_from(node_F.compute_node_hash(index_id)).unwrap();
+        let siblings = vec![Some(node_F_hash), None, Some(node_C_hash.clone())];
+        let merkle_path_inputs = MerklePathWithNeighborsGadget::<MAX_DEPTH>::new(
+            &path,
+            &siblings,
+            &node_E,
+            [None, None], // it's a leaf node
+        )
+        .unwrap();
+
+        let circuit = TestMerklePathWithNeighborsGadget::<MAX_DEPTH> {
+            merkle_path_inputs,
+            end_node: node_E.clone(),
+            index_id,
+        };
+
+        let proof = run_circuit(circuit);
+
+        // build predecessor and successor info for node_E
+        // There should be no predecessor
+        let predecessor_info = NeighborInfo {
+            is_found: false,
+            is_in_path: true, // the circuit still looks at the predecessor in the path
+            value: U256::ZERO,
+            hash: *empty_poseidon_hash(),
+        };
+        // successor should be node_D
+        let successor_info = NeighborInfo {
+            is_found: true,
+            is_in_path: true,
+            value: node_D.value,
+            hash: node_D_hash,
+        };
+        check_public_inputs(proof, &node_E, "node E", predecessor_info, successor_info);
+
+        // verify Merkle-path related to node D
+        let path = vec![
+            (node_B.clone(), ChildPosition::Left),
+            (node_A.clone(), ChildPosition::Left),
+        ];
+        let siblings = vec![None, Some(node_C_hash.clone())];
+        let merkle_path_inputs = MerklePathWithNeighborsGadget::<MAX_DEPTH>::new(
+            &path,
+            &siblings,
+            &node_D,
+            [Some(node_E.clone()), Some(node_F.clone())],
+        )
+        .unwrap();
+
+        let circuit = TestMerklePathWithNeighborsGadget::<MAX_DEPTH> {
+            merkle_path_inputs,
+            end_node: node_D.clone(),
+            index_id,
+        };
+
+        let proof = run_circuit(circuit);
+
+        // build predecessor and successor info for node_D
+        // predecessor should be node_E, but it's not in the path
+        let predecessor_info = NeighborInfo {
+            is_found: true,
+            is_in_path: false,
+            value: node_E.value,
+            hash: *empty_poseidon_hash(), // dummy value since the predecessor is not found in the path
+        };
+        // successor should be node_F, but it's not in the path
+        let successor_info = NeighborInfo {
+            is_found: true,
+            is_in_path: false,
+            value: node_F.value,
+            hash: *empty_poseidon_hash(), // dummy value since the predecessor is not found in the path
+        };
+        check_public_inputs(proof, &node_D, "node D", predecessor_info, successor_info);
+
+        // verify Merkle-path related to node B
+        let path = vec![(node_A.clone(), ChildPosition::Left)];
+        let siblings = vec![Some(node_C_hash.clone())];
+        let merkle_path_inputs = MerklePathWithNeighborsGadget::<MAX_DEPTH>::new(
+            &path,
+            &siblings,
+            &node_B,
+            [Some(node_D.clone()), None], // Node D is the left child
+        )
+        .unwrap();
+
+        let circuit = TestMerklePathWithNeighborsGadget::<MAX_DEPTH> {
+            merkle_path_inputs,
+            end_node: node_B.clone(),
+            index_id,
+        };
+
+        let proof = run_circuit(circuit);
+
+        // build predecessor and successor info for node_B
+        // predecessor should be node_F, but it's not in the path
+        let predecessor_info = NeighborInfo {
+            is_found: true,
+            is_in_path: false,
+            value: node_F.value,
+            hash: *empty_poseidon_hash(), // dummy value since the predecessor is not found in the path
+        };
+        // successor should be node_A
+        let successor_info = NeighborInfo {
+            is_found: true,
+            is_in_path: true,
+            value: node_A.value,
+            hash: root,
+        };
+        check_public_inputs(proof, &node_B, "node B", predecessor_info, successor_info);
+
+        // verify Merkle-path related to leaf G
+        let path = vec![
+            (node_C.clone(), ChildPosition::Right),
+            (node_A.clone(), ChildPosition::Right),
+        ];
+        let siblings = vec![
+            None,
+            Some(HashOutput::try_from(node_B_hash.to_bytes()).unwrap()),
+        ];
+        let merkle_path_inputs = MerklePathWithNeighborsGadget::<MAX_DEPTH>::new(
+            &path,
+            &siblings,
+            &node_G,
+            [None, None], // it's a leaf node
+        )
+        .unwrap();
+
+        let circuit = TestMerklePathWithNeighborsGadget::<MAX_DEPTH> {
+            merkle_path_inputs,
+            end_node: node_G.clone(),
+            index_id,
+        };
+
+        let proof = run_circuit(circuit);
+
+        // build predecessor and successor info for node_G
+        // predecessor should be node_C
+        let predecessor_info = NeighborInfo {
+            is_found: true,
+            is_in_path: true,
+            value: node_C.value,
+            hash: HashOut::from_bytes((&node_C_hash).into()),
+        };
+        // There should be no successor
+        let successor_info = NeighborInfo {
+            is_found: false,
+            is_in_path: true,
+            value: U256::ZERO,
+            hash: *empty_poseidon_hash(),
+        };
+        check_public_inputs(proof, &node_G, "node G", predecessor_info, successor_info);
+
+        // verify Merkle-path related to root node A
+        let path = vec![];
+        let siblings = vec![];
+        let merkle_path_inputs = MerklePathWithNeighborsGadget::<MAX_DEPTH>::new(
+            &path,
+            &siblings,
+            &node_A,
+            [Some(node_B), Some(node_C)], // it's a leaf node
+        )
+        .unwrap();
+
+        let circuit = TestMerklePathWithNeighborsGadget::<MAX_DEPTH> {
+            merkle_path_inputs,
+            end_node: node_A.clone(),
+            index_id,
+        };
+
+        let proof = run_circuit(circuit);
+
+        // build predecessor and successor info for node_A
+        // predecessor should be node_B, but it's not in the path
+        let predecessor_info = NeighborInfo {
+            is_found: true,
+            is_in_path: false,
+            value: node_B.value,
+            hash: *empty_poseidon_hash(), // dummy value since the predecessor is not found in the path
+        };
+        // successor should be node_C, but it's not in the path
+        let successor_info = NeighborInfo {
+            is_found: true,
+            is_in_path: false,
+            value: node_C.value,
+            hash: *empty_poseidon_hash(), // dummy value since the successor is not found in the path
+        };
+        check_public_inputs(proof, &node_A, "node A", predecessor_info, successor_info);
     }
 }

--- a/verifiable-db/src/query/universal_circuit/basic_operation.rs
+++ b/verifiable-db/src/query/universal_circuit/basic_operation.rs
@@ -47,7 +47,6 @@ pub(crate) struct BasicOperationValueWires {
 }
 /// Input + output wires for the computational hash of basic operation component
 pub(crate) struct BasicOperationHashWires {
-
     pub(crate) input_wires: BasicOperationInputWires,
     pub(crate) output_hash: ComputationalHashTarget,
 }
@@ -93,12 +92,11 @@ impl BasicOperationInputs {
     }
 
     pub(crate) fn build_values(
-        b: &mut CircuitBuilder<F, D>, 
+        b: &mut CircuitBuilder<F, D>,
         input_values: &[UInt256Target],
         input_wires: &BasicOperationInputWires,
         num_overflows: Target,
-    ) -> BasicOperationValueWires 
-    {
+    ) -> BasicOperationValueWires {
         let zero = b.zero();
         let possible_input_values = input_values
             .iter()
@@ -107,10 +105,14 @@ impl BasicOperationInputs {
             .cloned()
             .collect_vec();
         //TODO: these 2 random accesses could be done with a single operation, if we add an ad-hoc gate
-        let first_input =
-            b.random_access_u256(input_wires.first_input_selector, possible_input_values.as_slice());
-        let second_input =
-            b.random_access_u256(input_wires.second_input_selector, possible_input_values.as_slice());
+        let first_input = b.random_access_u256(
+            input_wires.first_input_selector,
+            possible_input_values.as_slice(),
+        );
+        let second_input = b.random_access_u256(
+            input_wires.second_input_selector,
+            possible_input_values.as_slice(),
+        );
 
         // compute results for all the operations
 
@@ -205,11 +207,12 @@ impl BasicOperationInputs {
             possible_overflows_occurred.len() <= 64,
             "random access gadget works only for arrays with at most 64 elements"
         );
-        let overflows_occurred = b.random_access(input_wires.op_selector, possible_overflows_occurred);
+        let overflows_occurred =
+            b.random_access(input_wires.op_selector, possible_overflows_occurred);
 
         BasicOperationValueWires {
-            output_value, 
-            num_overflows: b.add(num_overflows, overflows_occurred), 
+            output_value,
+            num_overflows: b.add(num_overflows, overflows_occurred),
         }
     }
 
@@ -250,9 +253,9 @@ impl BasicOperationInputs {
             input_wires.op_selector,
         );
 
-        BasicOperationHashWires { 
-            input_wires, 
-            output_hash, 
+        BasicOperationHashWires {
+            input_wires,
+            output_hash,
         }
     }
 
@@ -262,16 +265,11 @@ impl BasicOperationInputs {
         input_hash: &[ComputationalHashTarget],
         num_overflows: Target,
     ) -> BasicOperationWires {
-
         let hash_wires = Self::build_hash(b, input_hash);
-        
-        let value_wires = Self::build_values(
-            b, 
-            input_values, 
-            &hash_wires.input_wires, 
-            num_overflows
-        );
-        
+
+        let value_wires =
+            Self::build_values(b, input_values, &hash_wires.input_wires, num_overflows);
+
         BasicOperationWires {
             value_wires,
             hash_wires,

--- a/verifiable-db/src/query/universal_circuit/column_extraction.rs
+++ b/verifiable-db/src/query/universal_circuit/column_extraction.rs
@@ -45,7 +45,7 @@ pub(crate) struct ColumnExtractionValueWires<const MAX_NUM_COLUMNS: usize> {
 pub(crate) struct ColumnExtractionHashWires<const MAX_NUM_COLUMNS: usize> {
     pub(crate) input_wires: ColumnExtractionInputWires<MAX_NUM_COLUMNS>,
     /// Computational hash associated to the extraction of each of the `MAX_NUM_COLUMNS` columns
-    pub(crate) column_hash: [ComputationalHashTarget; MAX_NUM_COLUMNS], 
+    pub(crate) column_hash: [ComputationalHashTarget; MAX_NUM_COLUMNS],
 }
 
 /// Input + output wires for the column extraction component
@@ -74,23 +74,16 @@ impl<const MAX_NUM_COLUMNS: usize> ColumnExtractionInputs<MAX_NUM_COLUMNS> {
         column_values: &[UInt256Target; MAX_NUM_COLUMNS],
         input_wires: &ColumnExtractionInputWires<MAX_NUM_COLUMNS>,
     ) -> ColumnExtractionValueWires<MAX_NUM_COLUMNS> {
-            
         // Exclude the first 2 indexed columns to build the cells tree.
         let input_values = &column_values[2..];
         let input_ids = &input_wires.column_ids[2..];
         let is_real_value = &input_wires.is_real_column[2..];
         let tree_hash = build_cells_tree(b, input_values, input_ids, is_real_value);
 
-
-        ColumnExtractionValueWires {
-            tree_hash,
-        }
-
+        ColumnExtractionValueWires { tree_hash }
     }
 
-    pub(crate) fn build_hash(
-        b: &mut CBuilder,
-    ) -> ColumnExtractionHashWires<MAX_NUM_COLUMNS> {
+    pub(crate) fn build_hash(b: &mut CBuilder) -> ColumnExtractionHashWires<MAX_NUM_COLUMNS> {
         // Initialize the input wires.
         let input_wires = ColumnExtractionInputWires {
             column_ids: b.add_virtual_target_arr(),
@@ -104,21 +97,15 @@ impl<const MAX_NUM_COLUMNS: usize> ColumnExtractionInputs<MAX_NUM_COLUMNS> {
             input_wires,
             column_hash,
         }
-
     }
 
     pub(crate) fn build(
-        b: &mut CBuilder, 
+        b: &mut CBuilder,
         column_values: &[UInt256Target; MAX_NUM_COLUMNS],
     ) -> ColumnExtractionWires<MAX_NUM_COLUMNS> {
         let hash_wires = Self::build_hash(b);
-        let value_wires = Self::build_tree_hash(
-            b, 
-            column_values,
-            &hash_wires.input_wires
-        );
+        let value_wires = Self::build_tree_hash(b, column_values, &hash_wires.input_wires);
 
-        
         ColumnExtractionWires {
             value_wires,
             hash_wires,

--- a/verifiable-db/src/query/universal_circuit/mod.rs
+++ b/verifiable-db/src/query/universal_circuit/mod.rs
@@ -14,13 +14,13 @@ pub(crate) mod output_no_aggregation;
 /// Output component for queries with aggregation operations (i.e., `SUM` or `MIN`) specified in the `SELECT` statement,
 /// described here: https://www.notion.so/lagrangelabs/Queries-Circuits-2695199166a54954bbc44ad9dc398825?pvs=4#3e0a95407a4a474ca8f0fe45b913ea70
 pub(crate) mod output_with_aggregation;
-/// Gadget to process a single row in the DB according to a specific query
-pub(crate) mod universal_query_gadget;
 /// Universal query circuit, employing several instances of the atomic components found in other modules to process
 /// a single row of a table according to a given query. The overall layout of the circuit is described here
 /// https://www.notion.so/lagrangelabs/Queries-Circuits-2695199166a54954bbc44ad9dc398825?pvs=4#5c0d5af8c40f4bf0ae7dd13b20a54dcc
 /// while the detailed specs can be found here https://www.notion.so/lagrangelabs/Queries-Circuits-2695199166a54954bbc44ad9dc398825?pvs=4#22fbb552e11e411e95d426264c94aa46
 pub mod universal_query_circuit;
+/// Gadget to process a single row in the DB according to a specific query
+pub(crate) mod universal_query_gadget;
 
 /// Set of data structures to be provided as input to initialize a universal query circuit to prove
 /// the query computation for a single row. They basically allow to represent in a strucutred format

--- a/verifiable-db/src/query/universal_circuit/mod.rs
+++ b/verifiable-db/src/query/universal_circuit/mod.rs
@@ -14,6 +14,8 @@ pub(crate) mod output_no_aggregation;
 /// Output component for queries with aggregation operations (i.e., `SUM` or `MIN`) specified in the `SELECT` statement,
 /// described here: https://www.notion.so/lagrangelabs/Queries-Circuits-2695199166a54954bbc44ad9dc398825?pvs=4#3e0a95407a4a474ca8f0fe45b913ea70
 pub(crate) mod output_with_aggregation;
+/// Gadget to process a single row in the DB according to a specific query
+pub(crate) mod universal_query_gadget;
 /// Universal query circuit, employing several instances of the atomic components found in other modules to process
 /// a single row of a table according to a given query. The overall layout of the circuit is described here
 /// https://www.notion.so/lagrangelabs/Queries-Circuits-2695199166a54954bbc44ad9dc398825?pvs=4#5c0d5af8c40f4bf0ae7dd13b20a54dcc

--- a/verifiable-db/src/query/universal_circuit/output_no_aggregation.rs
+++ b/verifiable-db/src/query/universal_circuit/output_no_aggregation.rs
@@ -25,7 +25,9 @@ use std::{
 
 use super::{
     cells::build_cells_tree,
-    universal_query_gadget::{OutputComponent, OutputComponentHashWires, OutputComponentValueWires, OutputComponentWires},
+    universal_query_gadget::{
+        OutputComponent, OutputComponentHashWires, OutputComponentValueWires, OutputComponentWires,
+    },
     ComputationalHashTarget,
 };
 
@@ -101,12 +103,12 @@ impl<const MAX_NUM_RESULTS: usize> OutputComponentValueWires for ValueWires<MAX_
 
     fn other_output_values(&self) -> &[UInt256Target] {
         &self.output_values
-    }    
+    }
 }
 
 impl<const MAX_NUM_RESULTS: usize> OutputComponentHashWires for HashWires<MAX_NUM_RESULTS> {
     type InputWires = InputWires<MAX_NUM_RESULTS>;
-    
+
     fn ops_ids(&self) -> &[Target] {
         self.ops_ids.as_slice()
     }
@@ -161,7 +163,7 @@ impl<const MAX_NUM_RESULTS: usize> OutputComponent<MAX_NUM_RESULTS> for Circuit<
     fn output_variant() -> Output {
         Output::NoAggregation
     }
-    
+
     fn build_values<const NUM_OUTPUT_VALUES: usize>(
         b: &mut CBuilder,
         possible_output_values: [UInt256Target; NUM_OUTPUT_VALUES],
@@ -170,8 +172,6 @@ impl<const MAX_NUM_RESULTS: usize> OutputComponent<MAX_NUM_RESULTS> for Circuit<
     ) -> Self::ValueWires {
         let u256_zero = b.zero_u256();
         let curve_zero = b.curve_zero();
-
-
 
         // Build the output items to be returned.
         let output_items: [_; MAX_NUM_RESULTS] = array::from_fn(|i| {
@@ -211,7 +211,7 @@ impl<const MAX_NUM_RESULTS: usize> OutputComponent<MAX_NUM_RESULTS> for Circuit<
             output_values,
         }
     }
-    
+
     fn build_hash<const NUM_OUTPUT_VALUES: usize>(
         b: &mut CBuilder,
         possible_output_hash: [ComputationalHashTarget; NUM_OUTPUT_VALUES],
@@ -547,7 +547,10 @@ mod tests {
             );
 
             // Check the first output value and the output hash as expected.
-            b.connect_curve_points(wires.value_wires.first_output_value, expected.first_output_value);
+            b.connect_curve_points(
+                wires.value_wires.first_output_value,
+                expected.first_output_value,
+            );
             b.connect_hashes(wires.hash_wires.output_hash, expected.output_hash);
 
             // Check the remaining output values must be all zeros.

--- a/verifiable-db/src/query/universal_circuit/output_no_aggregation.rs
+++ b/verifiable-db/src/query/universal_circuit/output_no_aggregation.rs
@@ -25,7 +25,7 @@ use std::{
 
 use super::{
     cells::build_cells_tree,
-    universal_query_circuit::{OutputComponent, OutputComponentWires},
+    universal_query_gadget::{OutputComponent, OutputComponentHashWires, OutputComponentValueWires, OutputComponentWires},
     ComputationalHashTarget,
 };
 
@@ -56,20 +56,26 @@ pub struct InputWires<const MAX_NUM_RESULTS: usize> {
     is_output_valid: [BoolTarget; MAX_NUM_RESULTS],
 }
 
-/// Input + output wires for output component for queries without results aggregation
-pub struct Wires<const MAX_NUM_RESULTS: usize> {
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct HashWires<const MAX_NUM_RESULTS: usize> {
     /// input wires of the component
     input_wires: InputWires<MAX_NUM_RESULTS>,
-    /// The first output value computed by this component; it is a `CurveTarget` since
-    /// it corresponds to the accumulator of all the results of the query
-    first_output_value: CurveTarget,
-    /// Remaining output values; for this component, they are basically dummy values
-    output_values: Vec<UInt256Target>,
+
     /// Computational hash representing all the computation done in the query circuit
     output_hash: ComputationalHashTarget,
     /// Identifiers of the aggregation operations to be returned as public inputs
     ops_ids: [Target; MAX_NUM_RESULTS],
 }
+
+#[derive(Clone, Debug)]
+pub(crate) struct ValueWires<const MAX_NUM_RESULTS: usize> {
+    /// The first output value computed by this component; it is a `CurveTarget` since
+    /// it corresponds to the accumulator of all the results of the query
+    first_output_value: CurveTarget,
+    /// Remaining output values; for this component, they are basically dummy values
+    output_values: Vec<UInt256Target>,
+}
+
 /// Witness input values for output component for queries without results aggregation
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Circuit<const MAX_NUM_RESULTS: usize> {
@@ -86,21 +92,23 @@ pub struct Circuit<const MAX_NUM_RESULTS: usize> {
     ids: [F; MAX_NUM_RESULTS],
 }
 
-impl<const MAX_NUM_RESULTS: usize> OutputComponentWires for Wires<MAX_NUM_RESULTS> {
+impl<const MAX_NUM_RESULTS: usize> OutputComponentValueWires for ValueWires<MAX_NUM_RESULTS> {
     type FirstT = CurveTarget;
 
-    type InputWires = InputWires<MAX_NUM_RESULTS>;
-
-    fn ops_ids(&self) -> &[Target] {
-        self.ops_ids.as_slice()
-    }
-
     fn first_output_value(&self) -> Self::FirstT {
-        self.first_output_value
+        self.first_output_value.clone()
     }
 
     fn other_output_values(&self) -> &[UInt256Target] {
-        self.output_values.as_slice()
+        &self.output_values
+    }    
+}
+
+impl<const MAX_NUM_RESULTS: usize> OutputComponentHashWires for HashWires<MAX_NUM_RESULTS> {
+    type InputWires = InputWires<MAX_NUM_RESULTS>;
+    
+    fn ops_ids(&self) -> &[Target] {
+        self.ops_ids.as_slice()
     }
 
     fn computational_hash(&self) -> ComputationalHashTarget {
@@ -113,87 +121,8 @@ impl<const MAX_NUM_RESULTS: usize> OutputComponentWires for Wires<MAX_NUM_RESULT
 }
 
 impl<const MAX_NUM_RESULTS: usize> OutputComponent<MAX_NUM_RESULTS> for Circuit<MAX_NUM_RESULTS> {
-    type Wires = Wires<MAX_NUM_RESULTS>;
-
-    fn build<const NUM_OUTPUT_VALUES: usize>(
-        b: &mut CBuilder,
-        possible_output_values: [UInt256Target; NUM_OUTPUT_VALUES],
-        possible_output_hash: [ComputationalHashTarget; NUM_OUTPUT_VALUES],
-        predicate_value: &BoolTarget,
-        predicate_hash: &ComputationalHashTarget,
-    ) -> Self::Wires {
-        let u256_zero = b.zero_u256();
-        let curve_zero = b.curve_zero();
-
-        // Initialize the input wires.
-        let input_wires = InputWires {
-            selector: b.add_virtual_target_arr(),
-            ids: b.add_virtual_target_arr(),
-            is_output_valid: [0; MAX_NUM_RESULTS].map(|_| b.add_virtual_bool_target_safe()),
-        };
-
-        // Build the output items to be returned.
-        let output_items: [_; MAX_NUM_RESULTS] = array::from_fn(|i| {
-            b.random_access_u256(input_wires.selector[i], &possible_output_values)
-        });
-
-        // Compute the cells tree of the all output items to be returned for the given record.
-        let tree_hash = build_cells_tree(
-            b,
-            &output_items[2..],
-            &input_wires.ids[2..],
-            &input_wires.is_output_valid[2..],
-        );
-
-        // Compute the accumulator including the indexed items:
-        // second_item = is_output_valid[1] ? output_items[1] : 0
-        // accumulator = D(ids[0] || output_items[0] || ids[1] || second_item || tree_hash)
-        let second_item =
-            b.select_u256(input_wires.is_output_valid[1], &output_items[1], &u256_zero);
-        let inputs: Vec<_> = iter::once(input_wires.ids[0])
-            .chain(output_items[0].to_targets())
-            .chain(iter::once(input_wires.ids[1]))
-            .chain(second_item.to_targets())
-            .chain(tree_hash.to_targets())
-            .collect();
-        let accumulator = b.map_to_curve_point(&inputs);
-
-        // Expose the accumulator only if the results for this record have to be
-        // included in the query results.
-        let first_output_value = b.curve_select(*predicate_value, accumulator, curve_zero);
-
-        // Set the remaining outputs to dummy values.
-        let output_values = vec![u256_zero; MAX_NUM_RESULTS - 1];
-
-        // Compute the computational hash representing the accumulation of the items.
-        let output_hash = Self::output_variant().output_hash_circuit(
-            b,
-            predicate_hash,
-            &possible_output_hash,
-            &input_wires.selector,
-            &input_wires.ids,
-            &input_wires.is_output_valid,
-        );
-
-        // For the no aggregation operations, the first value in V contains the
-        // accumulator, while the other slots are filled by the dummy zero values.
-        // So the circuit claims that there is no aggregation operation on the
-        // first value in V, while all the other values can be simply summed up.
-        let [op_id, op_sum] = [AggregationOperation::IdOp, AggregationOperation::SumOp]
-            .map(|op| b.constant(Identifiers::AggregationOperations(op).to_field()));
-        let ops_ids: Vec<_> = iter::once(op_id)
-            .chain(iter::repeat(op_sum).take(MAX_NUM_RESULTS - 1))
-            .collect();
-        let ops_ids = ops_ids.try_into().unwrap();
-
-        Self::Wires {
-            input_wires,
-            first_output_value,
-            output_values,
-            output_hash,
-            ops_ids,
-        }
-    }
+    type HashWires = HashWires<MAX_NUM_RESULTS>;
+    type ValueWires = ValueWires<MAX_NUM_RESULTS>;
 
     fn assign(&self, pw: &mut PartialWitness<F>, wires: &InputWires<MAX_NUM_RESULTS>) {
         pw.set_target_arr(wires.selector.as_slice(), self.selector.as_slice());
@@ -231,6 +160,96 @@ impl<const MAX_NUM_RESULTS: usize> OutputComponent<MAX_NUM_RESULTS> for Circuit<
 
     fn output_variant() -> Output {
         Output::NoAggregation
+    }
+    
+    fn build_values<const NUM_OUTPUT_VALUES: usize>(
+        b: &mut CBuilder,
+        possible_output_values: [UInt256Target; NUM_OUTPUT_VALUES],
+        predicate_value: &BoolTarget,
+        input_wires: &<Self::HashWires as OutputComponentHashWires>::InputWires,
+    ) -> Self::ValueWires {
+        let u256_zero = b.zero_u256();
+        let curve_zero = b.curve_zero();
+
+
+
+        // Build the output items to be returned.
+        let output_items: [_; MAX_NUM_RESULTS] = array::from_fn(|i| {
+            b.random_access_u256(input_wires.selector[i], &possible_output_values)
+        });
+
+        // Compute the cells tree of the all output items to be returned for the given record.
+        let tree_hash = build_cells_tree(
+            b,
+            &output_items[2..],
+            &input_wires.ids[2..],
+            &input_wires.is_output_valid[2..],
+        );
+
+        // Compute the accumulator including the indexed items:
+        // second_item = is_output_valid[1] ? output_items[1] : 0
+        // accumulator = D(ids[0] || output_items[0] || ids[1] || second_item || tree_hash)
+        let second_item =
+            b.select_u256(input_wires.is_output_valid[1], &output_items[1], &u256_zero);
+        let inputs: Vec<_> = iter::once(input_wires.ids[0])
+            .chain(output_items[0].to_targets())
+            .chain(iter::once(input_wires.ids[1]))
+            .chain(second_item.to_targets())
+            .chain(tree_hash.to_targets())
+            .collect();
+        let accumulator = b.map_to_curve_point(&inputs);
+
+        // Expose the accumulator only if the results for this record have to be
+        // included in the query results.
+        let first_output_value = b.curve_select(*predicate_value, accumulator, curve_zero);
+
+        // Set the remaining outputs to dummy values.
+        let output_values = vec![u256_zero; MAX_NUM_RESULTS - 1];
+
+        ValueWires {
+            first_output_value,
+            output_values,
+        }
+    }
+    
+    fn build_hash<const NUM_OUTPUT_VALUES: usize>(
+        b: &mut CBuilder,
+        possible_output_hash: [ComputationalHashTarget; NUM_OUTPUT_VALUES],
+        predicate_hash: &ComputationalHashTarget,
+    ) -> Self::HashWires {
+        // Initialize the input wires.
+        let input_wires = InputWires {
+            selector: b.add_virtual_target_arr(),
+            ids: b.add_virtual_target_arr(),
+            is_output_valid: [0; MAX_NUM_RESULTS].map(|_| b.add_virtual_bool_target_safe()),
+        };
+
+        // Compute the computational hash representing the accumulation of the items.
+        let output_hash = Self::output_variant().output_hash_circuit(
+            b,
+            predicate_hash,
+            &possible_output_hash,
+            &input_wires.selector,
+            &input_wires.ids,
+            &input_wires.is_output_valid,
+        );
+
+        // For the no aggregation operations, the first value in V contains the
+        // accumulator, while the other slots are filled by the dummy zero values.
+        // So the circuit claims that there is no aggregation operation on the
+        // first value in V, while all the other values can be simply summed up.
+        let [op_id, op_sum] = [AggregationOperation::IdOp, AggregationOperation::SumOp]
+            .map(|op| b.constant(Identifiers::AggregationOperations(op).to_field()));
+        let ops_ids: Vec<_> = iter::once(op_id)
+            .chain(iter::repeat(op_sum).take(MAX_NUM_RESULTS - 1))
+            .collect();
+        let ops_ids = ops_ids.try_into().unwrap();
+
+        HashWires {
+            input_wires,
+            output_hash,
+            ops_ids,
+        }
     }
 }
 
@@ -497,7 +516,7 @@ mod tests {
     {
         // Circuit wires + output wires + expected wires
         type Wires = (
-            Wires<MAX_NUM_RESULTS>,
+            InputWires<MAX_NUM_RESULTS>,
             TestOutputWires<NUM_COLUMNS, MAX_NUM_RESULTS>,
             TestExpectedWires,
         );
@@ -528,11 +547,12 @@ mod tests {
             );
 
             // Check the first output value and the output hash as expected.
-            b.connect_curve_points(wires.first_output_value, expected.first_output_value);
-            b.connect_hashes(wires.output_hash, expected.output_hash);
+            b.connect_curve_points(wires.value_wires.first_output_value, expected.first_output_value);
+            b.connect_hashes(wires.hash_wires.output_hash, expected.output_hash);
 
             // Check the remaining output values must be all zeros.
             wires
+                .value_wires
                 .output_values
                 .iter()
                 .for_each(|t| b.enforce_equal_u256(t, &u256_zero));
@@ -540,16 +560,16 @@ mod tests {
             // Check the first OP is ID, and the remainings are SUM.
             let [op_id, op_sum] = [AggregationOperation::IdOp, AggregationOperation::SumOp]
                 .map(|op| b.constant(Identifiers::AggregationOperations(op).to_field()));
-            b.connect(wires.ops_ids[0], op_id);
-            wires.ops_ids[1..]
+            b.connect(wires.hash_wires.ops_ids[0], op_id);
+            wires.hash_wires.ops_ids[1..]
                 .iter()
                 .for_each(|t| b.connect(*t, op_sum));
 
-            (wires, output, expected)
+            (wires.hash_wires.input_wires, output, expected)
         }
 
         fn prove(&self, pw: &mut PartialWitness<F>, wires: &Self::Wires) {
-            self.c.assign(pw, &wires.0.input_wires);
+            self.c.assign(pw, &wires.0);
             self.output.assign(pw, &wires.1);
             self.expected.assign(pw, &wires.2);
         }

--- a/verifiable-db/src/query/universal_circuit/output_with_aggregation.rs
+++ b/verifiable-db/src/query/universal_circuit/output_with_aggregation.rs
@@ -21,7 +21,9 @@ use serde::{Deserialize, Serialize};
 use crate::query::computational_hash_ids::{AggregationOperation, Output};
 
 use super::{
-    universal_query_gadget::{OutputComponent, OutputComponentHashWires, OutputComponentValueWires, OutputComponentWires},
+    universal_query_gadget::{
+        OutputComponent, OutputComponentHashWires, OutputComponentValueWires, OutputComponentWires,
+    },
     ComputationalHashTarget,
 };
 
@@ -90,12 +92,12 @@ impl<const MAX_NUM_RESULTS: usize> OutputComponentValueWires for ValueWires<MAX_
 
     fn other_output_values(&self) -> &[UInt256Target] {
         &self.output_values[1..]
-    }    
+    }
 }
 
 impl<const MAX_NUM_RESULTS: usize> OutputComponentHashWires for HashWires<MAX_NUM_RESULTS> {
     type InputWires = InputWires<MAX_NUM_RESULTS>;
-    
+
     fn ops_ids(&self) -> &[Target] {
         self.input_wires.agg_ops.as_slice()
     }
@@ -150,7 +152,7 @@ impl<const MAX_NUM_RESULTS: usize> OutputComponent<MAX_NUM_RESULTS> for Circuit<
     fn output_variant() -> Output {
         Output::Aggregation
     }
-    
+
     fn build_values<const NUM_OUTPUT_VALUES: usize>(
         b: &mut CBuilder,
         possible_output_values: [UInt256Target; NUM_OUTPUT_VALUES],
@@ -165,7 +167,8 @@ impl<const MAX_NUM_RESULTS: usize> OutputComponent<MAX_NUM_RESULTS> for Circuit<
 
         for i in 0..MAX_NUM_RESULTS {
             // TODO: random accesses over different iterations can be done with a single operation if we introduce an ad-hoc gate
-            let output_value = b.random_access_u256(input_wires.selector[i], &possible_output_values);
+            let output_value =
+                b.random_access_u256(input_wires.selector[i], &possible_output_values);
 
             // If `predicate_value` is true, then expose the value to be aggregated;
             // Otherwise use the identity for the aggregation operation.
@@ -182,7 +185,7 @@ impl<const MAX_NUM_RESULTS: usize> OutputComponent<MAX_NUM_RESULTS> for Circuit<
             output_values: output_values.try_into().unwrap(),
         }
     }
-    
+
     fn build_hash<const NUM_OUTPUT_VALUES: usize>(
         b: &mut CBuilder,
         possible_output_hash: [ComputationalHashTarget; NUM_OUTPUT_VALUES],

--- a/verifiable-db/src/query/universal_circuit/output_with_aggregation.rs
+++ b/verifiable-db/src/query/universal_circuit/output_with_aggregation.rs
@@ -21,7 +21,7 @@ use serde::{Deserialize, Serialize};
 use crate::query::computational_hash_ids::{AggregationOperation, Output};
 
 use super::{
-    universal_query_circuit::{OutputComponent, OutputComponentWires},
+    universal_query_gadget::{OutputComponent, OutputComponentHashWires, OutputComponentValueWires, OutputComponentWires},
     ComputationalHashTarget,
 };
 
@@ -52,16 +52,19 @@ pub struct InputWires<const MAX_NUM_RESULTS: usize> {
     )]
     is_output_valid: [BoolTarget; MAX_NUM_RESULTS],
 }
-
 #[derive(Clone, Debug, Eq, PartialEq)]
-/// Input + output wires for output component for queries with result aggregation
-pub struct Wires<const MAX_NUM_RESULTS: usize> {
+pub(crate) struct HashWires<const MAX_NUM_RESULTS: usize> {
     input_wires: InputWires<MAX_NUM_RESULTS>,
-    /// Output values computed by this component
-    output_values: [UInt256Target; MAX_NUM_RESULTS],
     /// Computational hash representing all the computation done in the query circuit
     output_hash: ComputationalHashTarget,
 }
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct ValueWires<const MAX_NUM_RESULTS: usize> {
+    /// Output values computed by this component
+    output_values: [UInt256Target; MAX_NUM_RESULTS],
+}
+
 /// Input witness values for output component for queries with result aggregation
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 pub struct Circuit<const MAX_NUM_RESULTS: usize> {
@@ -78,14 +81,8 @@ pub struct Circuit<const MAX_NUM_RESULTS: usize> {
     num_valid_outputs: usize,
 }
 
-impl<const MAX_NUM_RESULTS: usize> OutputComponentWires for Wires<MAX_NUM_RESULTS> {
+impl<const MAX_NUM_RESULTS: usize> OutputComponentValueWires for ValueWires<MAX_NUM_RESULTS> {
     type FirstT = UInt256Target;
-
-    type InputWires = InputWires<MAX_NUM_RESULTS>;
-
-    fn ops_ids(&self) -> &[Target] {
-        self.input_wires.agg_ops.as_slice()
-    }
 
     fn first_output_value(&self) -> Self::FirstT {
         self.output_values[0].clone()
@@ -93,6 +90,14 @@ impl<const MAX_NUM_RESULTS: usize> OutputComponentWires for Wires<MAX_NUM_RESULT
 
     fn other_output_values(&self) -> &[UInt256Target] {
         &self.output_values[1..]
+    }    
+}
+
+impl<const MAX_NUM_RESULTS: usize> OutputComponentHashWires for HashWires<MAX_NUM_RESULTS> {
+    type InputWires = InputWires<MAX_NUM_RESULTS>;
+    
+    fn ops_ids(&self) -> &[Target] {
+        self.input_wires.agg_ops.as_slice()
     }
 
     fn computational_hash(&self) -> ComputationalHashTarget {
@@ -105,58 +110,8 @@ impl<const MAX_NUM_RESULTS: usize> OutputComponentWires for Wires<MAX_NUM_RESULT
 }
 
 impl<const MAX_NUM_RESULTS: usize> OutputComponent<MAX_NUM_RESULTS> for Circuit<MAX_NUM_RESULTS> {
-    type Wires = Wires<MAX_NUM_RESULTS>;
-
-    fn build<const NUM_OUTPUT_VALUES: usize>(
-        b: &mut CBuilder,
-        possible_output_values: [UInt256Target; NUM_OUTPUT_VALUES],
-        possible_output_hash: [ComputationalHashTarget; NUM_OUTPUT_VALUES],
-        predicate_value: &BoolTarget,
-        predicate_hash: &ComputationalHashTarget,
-    ) -> Self::Wires {
-        let selector = b.add_virtual_target_arr::<MAX_NUM_RESULTS>();
-        let agg_ops = b.add_virtual_target_arr::<MAX_NUM_RESULTS>();
-        let is_output_valid = array::from_fn(|_| b.add_virtual_bool_target_safe());
-        let u256_max = b.constant_u256(U256::MAX);
-        let zero = b.zero_u256();
-        let min_op_identifier = b.constant(AggregationOperation::MinOp.to_field());
-
-        let mut output_values = vec![];
-
-        for i in 0..MAX_NUM_RESULTS {
-            // TODO: random accesses over different iterations can be done with a single operation if we introduce an ad-hoc gate
-            let output_value = b.random_access_u256(selector[i], &possible_output_values);
-
-            // If `predicate_value` is true, then expose the value to be aggregated;
-            // Otherwise use the identity for the aggregation operation.
-            // The identity is 0 except for "MIN", where the identity is the biggest
-            // possible value in the domain, i.e. 2^256-1.
-            let is_agg_ops_min = b.is_equal(agg_ops[i], min_op_identifier);
-            let identity_value = b.select_u256(is_agg_ops_min, &u256_max, &zero);
-            let actual_output_value =
-                b.select_u256(*predicate_value, &output_value, &identity_value);
-            output_values.push(actual_output_value);
-        }
-
-        let output_hash = Self::output_variant().output_hash_circuit(
-            b,
-            predicate_hash,
-            &possible_output_hash,
-            &selector,
-            &agg_ops,
-            &is_output_valid,
-        );
-
-        Wires {
-            input_wires: InputWires {
-                selector,
-                agg_ops,
-                is_output_valid,
-            },
-            output_values: output_values.try_into().unwrap(),
-            output_hash,
-        }
-    }
+    type HashWires = HashWires<MAX_NUM_RESULTS>;
+    type ValueWires = ValueWires<MAX_NUM_RESULTS>;
 
     fn assign(&self, pw: &mut PartialWitness<F>, wires: &InputWires<MAX_NUM_RESULTS>) {
         pw.set_target_arr(wires.selector.as_slice(), self.selector.as_slice());
@@ -195,6 +150,67 @@ impl<const MAX_NUM_RESULTS: usize> OutputComponent<MAX_NUM_RESULTS> for Circuit<
     fn output_variant() -> Output {
         Output::Aggregation
     }
+    
+    fn build_values<const NUM_OUTPUT_VALUES: usize>(
+        b: &mut CBuilder,
+        possible_output_values: [UInt256Target; NUM_OUTPUT_VALUES],
+        predicate_value: &BoolTarget,
+        input_wires: &<Self::HashWires as OutputComponentHashWires>::InputWires,
+    ) -> Self::ValueWires {
+        let u256_max = b.constant_u256(U256::MAX);
+        let zero = b.zero_u256();
+        let min_op_identifier = b.constant(AggregationOperation::MinOp.to_field());
+
+        let mut output_values = vec![];
+
+        for i in 0..MAX_NUM_RESULTS {
+            // TODO: random accesses over different iterations can be done with a single operation if we introduce an ad-hoc gate
+            let output_value = b.random_access_u256(input_wires.selector[i], &possible_output_values);
+
+            // If `predicate_value` is true, then expose the value to be aggregated;
+            // Otherwise use the identity for the aggregation operation.
+            // The identity is 0 except for "MIN", where the identity is the biggest
+            // possible value in the domain, i.e. 2^256-1.
+            let is_agg_ops_min = b.is_equal(input_wires.agg_ops[i], min_op_identifier);
+            let identity_value = b.select_u256(is_agg_ops_min, &u256_max, &zero);
+            let actual_output_value =
+                b.select_u256(*predicate_value, &output_value, &identity_value);
+            output_values.push(actual_output_value);
+        }
+
+        ValueWires {
+            output_values: output_values.try_into().unwrap(),
+        }
+    }
+    
+    fn build_hash<const NUM_OUTPUT_VALUES: usize>(
+        b: &mut CBuilder,
+        possible_output_hash: [ComputationalHashTarget; NUM_OUTPUT_VALUES],
+        predicate_hash: &ComputationalHashTarget,
+    ) -> Self::HashWires {
+        let selector = b.add_virtual_target_arr::<MAX_NUM_RESULTS>();
+        let agg_ops = b.add_virtual_target_arr::<MAX_NUM_RESULTS>();
+        let is_output_valid = array::from_fn(|_| b.add_virtual_bool_target_safe());
+        let input_wires = InputWires {
+            selector,
+            agg_ops,
+            is_output_valid,
+        };
+
+        let output_hash = Self::output_variant().output_hash_circuit(
+            b,
+            predicate_hash,
+            &possible_output_hash,
+            &input_wires.selector,
+            &input_wires.agg_ops,
+            &input_wires.is_output_valid,
+        );
+
+        HashWires {
+            input_wires,
+            output_hash,
+        }
+    }
 }
 
 #[cfg(test)]
@@ -227,7 +243,7 @@ mod tests {
         computational_hash_ids::{AggregationOperation, ComputationalHashCache},
         universal_circuit::{
             universal_circuit_inputs::OutputItem,
-            universal_query_circuit::{OutputComponent, OutputComponentWires},
+            universal_query_gadget::{OutputComponent, OutputComponentHashWires},
             ComputationalHash, ComputationalHashTarget,
         },
     };
@@ -312,14 +328,14 @@ mod tests {
 
             expected_output_values
                 .iter()
-                .zip(wires.output_values.iter())
+                .zip(wires.value_wires.output_values.iter())
                 .for_each(|(expected, actual)| c.enforce_equal_u256(expected, actual));
 
             expected_ops_ids
                 .iter()
-                .zip(wires.ops_ids().iter())
+                .zip(wires.hash_wires.ops_ids().iter())
                 .for_each(|(expected, actual)| c.connect(*expected, *actual));
-            c.connect_hashes(expected_output_hash, wires.output_hash);
+            c.connect_hashes(expected_output_hash, wires.hash_wires.output_hash);
 
             Self::Wires {
                 column_values,
@@ -328,7 +344,7 @@ mod tests {
                 item_hash: item_hash.try_into().unwrap(),
                 predicate_value,
                 predicate_hash,
-                component: wires.input_wires,
+                component: wires.hash_wires.input_wires,
                 expected_output_values,
                 expected_ops_ids,
                 expected_output_hash,

--- a/verifiable-db/src/query/universal_circuit/universal_circuit_inputs.rs
+++ b/verifiable-db/src/query/universal_circuit/universal_circuit_inputs.rs
@@ -9,7 +9,7 @@ use mp2_common::{
     F,
 };
 
-use crate::query::computational_hash_ids::{Operation, Output, PlaceholderIdentifier};
+use crate::query::computational_hash_ids::{ColumnIDs, Operation, Output, PlaceholderIdentifier};
 
 use super::universal_query_circuit::dummy_placeholder_id;
 
@@ -477,5 +477,13 @@ impl RowCells {
             .chain(&self.rest)
             .cloned()
             .collect_vec()
+    }
+
+    pub fn column_ids(&self) -> ColumnIDs {
+        ColumnIDs {
+            primary: self.primary.id,
+            secondary: self.secondary.id,
+            rest: self.rest.iter().map(|cell| cell.id).collect_vec(),
+        } 
     }
 }

--- a/verifiable-db/src/query/universal_circuit/universal_circuit_inputs.rs
+++ b/verifiable-db/src/query/universal_circuit/universal_circuit_inputs.rs
@@ -484,6 +484,6 @@ impl RowCells {
             primary: self.primary.id,
             secondary: self.secondary.id,
             rest: self.rest.iter().map(|cell| cell.id).collect_vec(),
-        } 
+        }
     }
 }

--- a/verifiable-db/src/query/universal_circuit/universal_query_circuit.rs
+++ b/verifiable-db/src/query/universal_circuit/universal_query_circuit.rs
@@ -1,383 +1,14 @@
-use std::{
-    fmt::Debug,
-    iter::{once, repeat},
-};
+use std::iter::once;
 
-use alloy::primitives::U256;
-use anyhow::{bail, ensure, Result};
 use itertools::Itertools;
-use mp2_common::{
-    array::ToField,
-    poseidon::{empty_poseidon_hash, H},
-    public_inputs::PublicInputCommon,
-    serialization::{deserialize, deserialize_long_array, serialize, serialize_long_array},
-    types::CBuilder,
-    u256::{CircuitBuilderU256, UInt256Target},
-    utils::{FromFields, SelectHashBuilder, ToFields, ToTargets},
-    CHasher, D, F,
-};
-use plonky2::{
-    field::types::Field,
-    hash::hashing::hash_n_to_hash_no_pad,
-    iop::{
-        target::{BoolTarget, Target},
-        witness::{PartialWitness, WitnessWrite},
-    },
-    plonk::{
-        circuit_builder::CircuitBuilder,
-        config::{GenericHashOut, Hasher},
-        proof::ProofWithPublicInputsTarget,
-    },
-};
+use mp2_common::{array::ToField, poseidon::{empty_poseidon_hash, HashPermutation}, public_inputs::PublicInputCommon, serialization::{deserialize, serialize}, utils::{SelectHashBuilder, ToFields, ToTargets}, CHasher, D, F};
+use plonky2::{hash::hashing::hash_n_to_hash_no_pad, iop::{target::{BoolTarget, Target}, witness::{PartialWitness, WitnessWrite}}, plonk::{circuit_builder::CircuitBuilder, proof::ProofWithPublicInputsTarget}};
 use recursion_framework::circuit_builder::CircuitLogicWires;
-use serde::{Deserialize, Serialize};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use anyhow::Result;
+use crate::query::{aggregation::QueryBounds, computational_hash_ids::PlaceholderIdentifier, public_inputs::PublicInputs, PI_LEN};
 
-use crate::query::{
-    aggregation::{QueryBoundSecondary, QueryBoundSource, QueryBounds},
-    computational_hash_ids::{
-        ComputationalHashCache, HashPermutation, Operation, Output, PlaceholderIdentifier,
-    },
-    public_inputs::PublicInputs,
-    universal_circuit::{
-        basic_operation::BasicOperationInputs, universal_circuit_inputs::OutputItem,
-    },
-    PI_LEN,
-};
-
-use super::{
-    basic_operation::{BasicOperationInputWires, BasicOperationWires},
-    column_extraction::{ColumnExtractionInputWires, ColumnExtractionInputs},
-    output_no_aggregation::Circuit as NoAggOutputCircuit,
-    output_with_aggregation::Circuit as AggOutputCircuit,
-    universal_circuit_inputs::{
-        BasicOperation, InputOperand, Placeholder, PlaceholderId, Placeholders, ResultStructure,
-        RowCells,
-    },
-    ComputationalHash, ComputationalHashTarget, PlaceholderHash, PlaceholderHashTarget,
-};
-
-/// Wires representing a query bound in the universal circuit
-pub(crate) type QueryBoundTarget = BasicOperationWires;
-
-/// Input wires for `QueryBoundTarget` (i.e., the wires that need to be assigned)
-pub(crate) type QueryBoundTargetInputs = BasicOperationInputWires;
-
-impl From<QueryBoundTarget> for QueryBoundTargetInputs {
-    fn from(value: QueryBoundTarget) -> Self {
-        value.input_wires
-    }
-}
-
-impl QueryBoundTarget {
-    pub(crate) fn new(b: &mut CBuilder) -> Self {
-        let zero_u256 = b.zero_u256();
-        let zero = b.zero();
-        let empty_hash = b.constant_hash(*empty_poseidon_hash());
-        // The 0 constant provided as input value is used as a dummy operand in case the query bound
-        // is taken from a constant in the query: in this case, the query bound in the circuit is
-        // computed with the operation `InputOperand::Constant(query_bound) + input_values[0]`, which
-        // yields `query_bound` as output since `input_values[0] = 0`. The constant input values 0 is
-        // associated to the empty hash in the computational hash, which is provided as `input_hash[0]`
-        BasicOperationInputs::build(b, &[zero_u256], &[empty_hash], zero)
-    }
-
-    /// Get the actual value of this query bound computed in the circuit
-    pub(crate) fn get_bound_value(&self) -> &UInt256Target {
-        &self.output_value
-    }
-
-    // Compute the number of overflows occurred during operations to compute query bounds
-    pub(crate) fn num_overflows_for_query_bound_operations(
-        b: &mut CBuilder,
-        min_query: &Self,
-        max_query: &Self,
-    ) -> Target {
-        b.add(min_query.num_overflows, max_query.num_overflows)
-    }
-
-    pub(crate) fn add_query_bounds_to_placeholder_hash(
-        b: &mut CBuilder,
-        min_query_bound: &Self,
-        max_query_bound: &Self,
-        placeholder_hash: &PlaceholderHashTarget,
-    ) -> PlaceholderHashTarget {
-        b.hash_n_to_hash_no_pad::<CHasher>(
-            placeholder_hash
-                .elements
-                .iter()
-                .chain(once(&min_query_bound.input_wires.placeholder_ids[0]))
-                .chain(&min_query_bound.input_wires.placeholder_values[0].to_targets())
-                .chain(once(&min_query_bound.input_wires.placeholder_ids[1]))
-                .chain(&min_query_bound.input_wires.placeholder_values[1].to_targets())
-                .chain(once(&max_query_bound.input_wires.placeholder_ids[0]))
-                .chain(&max_query_bound.input_wires.placeholder_values[0].to_targets())
-                .chain(once(&max_query_bound.input_wires.placeholder_ids[1]))
-                .chain(&max_query_bound.input_wires.placeholder_values[1].to_targets())
-                .cloned()
-                .collect(),
-        )
-    }
-
-    pub(crate) fn add_query_bounds_to_computational_hash(
-        b: &mut CBuilder,
-        min_query_bound: &Self,
-        max_query_bound: &Self,
-        computational_hash: &ComputationalHashTarget,
-    ) -> ComputationalHashTarget {
-        b.hash_n_to_hash_no_pad::<CHasher>(
-            computational_hash
-                .to_targets()
-                .into_iter()
-                .chain(min_query_bound.output_hash.to_targets())
-                .chain(max_query_bound.output_hash.to_targets())
-                .collect_vec(),
-        )
-    }
-}
-
-impl QueryBoundTargetInputs {
-    pub(crate) fn assign(&self, pw: &mut PartialWitness<F>, bound: &QueryBound) {
-        bound.operation.assign(pw, &self);
-    }
-}
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub(crate) struct QueryBound {
-    pub(crate) operation: BasicOperationInputs,
-}
-
-impl QueryBound {
-    /// Number of input values provided to the basic operation component computing the query bounds
-    /// in the circuit; currently it is 1 since the constant input value 0 is provided as a dummy
-    /// input value (see QueryBoundTarget::new()).
-    const NUM_INPUT_VALUES: usize = 1;
-
-    /// Initialize a query bound for the primary index, from the set of `placeholders` employed in the query,
-    /// which include also the primary index bounds by construction. The flag `is_min_bound`
-    /// must be true iff the bound to be initialized is a lower bound in the range specified in the query
-    pub(crate) fn new_primary_index_bound(
-        placeholders: &Placeholders,
-        is_min_bound: bool,
-    ) -> Result<Self> {
-        let source = QueryBoundSource::Placeholder(if is_min_bound {
-            PlaceholderIdentifier::MinQueryOnIdx1
-        } else {
-            PlaceholderIdentifier::MaxQueryOnIdx1
-        });
-        Self::new_bound(placeholders, &source)
-    }
-
-    /// Initialize a query bound for the secondary index, from the set of placeholders employed in the query
-    /// and from the provided `bound`, which specifies how the query bound should be computed in the circuit
-    pub(crate) fn new_secondary_index_bound(
-        placeholders: &Placeholders,
-        bound: &QueryBoundSecondary,
-    ) -> Result<Self> {
-        let source = bound.into();
-        Self::new_bound(placeholders, &source)
-    }
-
-    /// Internal function employed to instantiate a new query bound
-    fn new_bound(placeholders: &Placeholders, source: &QueryBoundSource) -> Result<Self> {
-        let dummy_placeholder = dummy_placeholder(placeholders);
-        let op_inputs = match source {
-            QueryBoundSource::Constant(value) =>
-            // if the query bound is computed from a constant `value`, we instantiate the operation
-            // `value + input_values[0]` in the circuit, as in `QueryBoundTarget` construction we
-            // always set `input_values[0] = 0`. This trick allows to get the same constant `value`
-            // as output of the basic operation employed in the circuit to compute the query bound
-            {
-                BasicOperationInputs {
-                    constant_operand: *value,
-                    placeholder_values: [dummy_placeholder.value, dummy_placeholder.value],
-                    placeholder_ids: [
-                        dummy_placeholder.id.to_field(),
-                        dummy_placeholder.id.to_field(),
-                    ],
-                    first_input_selector: BasicOperationInputs::constant_operand_offset(
-                        Self::NUM_INPUT_VALUES,
-                    )
-                    .to_field(),
-                    second_input_selector: BasicOperationInputs::input_value_offset(0).to_field(),
-                    op_selector: Operation::AddOp.to_field(),
-                }
-            }
-            QueryBoundSource::Placeholder(id) =>
-            // if the query bound is computed from a placeholder with id `id`, we instantiate
-            // the operation `$id + 0` in the circuit, which will yield the value of placeholder
-            // $id (which should correspond to the query bound) as output
-            {
-                BasicOperationInputs {
-                    constant_operand: U256::ZERO,
-                    placeholder_values: [placeholders.get(id)?, dummy_placeholder.value],
-                    placeholder_ids: [id.to_field(), dummy_placeholder.id.to_field()],
-                    first_input_selector: BasicOperationInputs::first_placeholder_offset(
-                        Self::NUM_INPUT_VALUES,
-                    )
-                    .to_field(),
-                    second_input_selector: BasicOperationInputs::constant_operand_offset(
-                        Self::NUM_INPUT_VALUES,
-                    )
-                    .to_field(),
-                    op_selector: Operation::AddOp.to_field(),
-                }
-            }
-            QueryBoundSource::Operation(op) => {
-                // In this case we instantiate the basic operation `op`, checking that the operation
-                // satisfies the requirements for query bound operations (i.e., it involves only
-                // constant values and placeholders)
-                let mut constant_operand = U256::ZERO;
-                let mut process_input_op = |operand: &InputOperand| {
-                    Ok(match operand {
-                        InputOperand::Placeholder(id) =>
-                            (
-                                *id,
-                                None,
-                            ),
-                        InputOperand::Constant(value) => {
-                            constant_operand = *value;
-                            (
-                                dummy_placeholder.id,
-                                Some(BasicOperationInputs::constant_operand_offset(Self::NUM_INPUT_VALUES))
-                            )
-                        },
-                        _ => bail!("Invalid operand for query bound operation: must be either a placeholder or a constant"),
-                    })
-                };
-
-                let (first_placeholder_id, first_selector) = process_input_op(&op.first_operand)?;
-                let (second_placeholder_id, second_selector) = process_input_op(
-                    &op.second_operand.unwrap_or_default(), // Unary operation, so use a dummy operand
-                )?;
-                BasicOperationInputs {
-                    constant_operand,
-                    placeholder_values: [
-                        placeholders.get(&first_placeholder_id)?,
-                        placeholders.get(&second_placeholder_id)?,
-                    ],
-                    placeholder_ids: [
-                        first_placeholder_id.to_field(),
-                        second_placeholder_id.to_field(),
-                    ],
-                    first_input_selector: first_selector
-                        .unwrap_or(BasicOperationInputs::first_placeholder_offset(
-                            Self::NUM_INPUT_VALUES,
-                        ))
-                        .to_field(),
-                    second_input_selector: second_selector
-                        .unwrap_or(BasicOperationInputs::second_placeholder_offset(
-                            Self::NUM_INPUT_VALUES,
-                        ))
-                        .to_field(),
-                    op_selector: op.op.to_field(),
-                }
-            }
-        };
-        Ok(Self {
-            operation: op_inputs,
-        })
-    }
-
-    /// This method computes the value of a query bound
-    pub(crate) fn compute_bound_value(
-        placeholders: &Placeholders,
-        source: &QueryBoundSource,
-    ) -> Result<(U256, bool)> {
-        Ok(match source {
-            QueryBoundSource::Constant(value) => (*value, false),
-            QueryBoundSource::Placeholder(id) => (placeholders.get(id)?, false),
-            QueryBoundSource::Operation(op) => {
-                let (values, overflow) =
-                    BasicOperation::compute_operations(&[*op], &[], placeholders)?;
-                (values[0], overflow)
-            }
-        })
-    }
-
-    /// This method returns the basic operation employed in the circuit for the query bound which is
-    /// taken fromthe query as specify by the input `source`. It basically returns the same operations
-    /// that are instantiated in the circuit by the `new_bound` internal method
-    pub(crate) fn get_basic_operation(source: &QueryBoundSource) -> Result<BasicOperation> {
-        Ok(match source {
-            QueryBoundSource::Constant(value) =>
-            // convert to operation `value + input_value[0]`, which yield value as `input_value[0] = 0` in the circuit
-            {
-                BasicOperation {
-                    first_operand: InputOperand::Constant(*value),
-                    second_operand: Some(InputOperand::Column(0)),
-                    op: Operation::AddOp,
-                }
-            }
-            QueryBoundSource::Placeholder(id) =>
-            // convert to operation $id + 0
-            {
-                BasicOperation {
-                    first_operand: InputOperand::Placeholder(*id),
-                    second_operand: Some(InputOperand::Constant(U256::ZERO)),
-                    op: Operation::AddOp,
-                }
-            }
-            QueryBoundSource::Operation(op) => {
-                // validate operation for query bound
-                match op.first_operand {
-                    InputOperand::Constant(_) | InputOperand::Placeholder(_) => (),
-                    _ => bail!("Invalid operand for query bound operation: must be either a placeholder or a constant")
-                }
-                if let Some(operand) = op.second_operand {
-                    match operand {
-                        InputOperand::Constant(_) | InputOperand::Placeholder(_) => (),
-                        _ => bail!("Invalid operand for query bound operation: must be either a placeholder or a constant")
-                    }
-                }
-                *op
-            }
-        })
-    }
-
-    pub(crate) fn add_secondary_query_bounds_to_placeholder_hash(
-        min_query: &Self,
-        max_query: &Self,
-        placeholder_hash: &PlaceholderHash,
-    ) -> PlaceholderHash {
-        hash_n_to_hash_no_pad::<_, HashPermutation>(
-            &placeholder_hash
-                .to_vec()
-                .into_iter()
-                .chain(once(min_query.operation.placeholder_ids[0]))
-                .chain(min_query.operation.placeholder_values[0].to_fields())
-                .chain(once(min_query.operation.placeholder_ids[1]))
-                .chain(min_query.operation.placeholder_values[1].to_fields())
-                .chain(once(max_query.operation.placeholder_ids[0]))
-                .chain(max_query.operation.placeholder_values[0].to_fields())
-                .chain(once(max_query.operation.placeholder_ids[1]))
-                .chain(max_query.operation.placeholder_values[1].to_fields())
-                .collect_vec(),
-        )
-    }
-
-    pub(crate) fn add_secondary_query_bounds_to_computational_hash(
-        min_query: &QueryBoundSource,
-        max_query: &QueryBoundSource,
-        computational_hash: &ComputationalHash,
-    ) -> Result<ComputationalHash> {
-        let min_query_op = Self::get_basic_operation(&min_query)?;
-        let max_query_op = Self::get_basic_operation(&max_query)?;
-        // initialize computational hash cache with the empty hash associated to the only input value (hardcoded to 0
-        // in the circuit) of the basic operation components employed for query bounds
-        let mut cache = ComputationalHashCache::new_from_column_hash(
-            Self::NUM_INPUT_VALUES,
-            &[*empty_poseidon_hash()],
-        )?;
-        let min_query_hash = Operation::basic_operation_hash(&mut cache, &[], &min_query_op)?;
-        let max_query_hash = Operation::basic_operation_hash(&mut cache, &[], &max_query_op)?;
-        let inputs = computational_hash
-            .to_vec()
-            .into_iter()
-            .chain(min_query_hash.to_fields())
-            .chain(max_query_hash.to_fields())
-            .collect_vec();
-        Ok(H::hash_no_pad(&inputs))
-    }
-}
+use super::{basic_operation::BasicOperationInputs, output_no_aggregation::Circuit as NoAggOutputCircuit, output_with_aggregation::Circuit as AggOutputCircuit, universal_circuit_inputs::{BasicOperation, PlaceholderId, Placeholders, ResultStructure, RowCells}, universal_query_gadget::{OutputComponent, UniversalQueryHashInputWires, UniversalQueryHashInputs, UniversalQueryValueInputWires, UniversalQueryValueInputs}, universal_query_gadget::QueryBound, PlaceholderHash};
 
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 /// Input wires for the universal query circuit
@@ -388,83 +19,13 @@ pub struct UniversalQueryCircuitWires<
     const MAX_NUM_RESULTS: usize,
     T: OutputComponent<MAX_NUM_RESULTS>,
 > {
-    /// Input wires for column extraction component
-    pub(crate) column_extraction_wires: ColumnExtractionInputWires<MAX_NUM_COLUMNS>,
     /// flag specifying whether the given row is stored in a leaf node of a rows tree or not
     #[serde(serialize_with = "serialize", deserialize_with = "deserialize")]
     is_leaf: BoolTarget,
-    /// Lower bound of the range for the secondary index specified in the query
-    min_query: QueryBoundTargetInputs,
-    /// Upper bound of the range for the secondary index specified in the query
-    max_query: QueryBoundTargetInputs,
-    /// Input wires for the `MAX_NUM_PREDICATE_OPS` basic operation components necessary
-    /// to evaluate the filtering predicate
-    #[serde(
-        serialize_with = "serialize_long_array",
-        deserialize_with = "deserialize_long_array"
-    )]
-    filtering_predicate_ops: [BasicOperationInputWires; MAX_NUM_PREDICATE_OPS],
-    /// Input wires for the `MAX_NUM_RESULT_OPS` basic operation components necessary
-    /// to compute the results for the current row
-    #[serde(
-        serialize_with = "serialize_long_array",
-        deserialize_with = "deserialize_long_array"
-    )]
-    result_value_ops: [BasicOperationInputWires; MAX_NUM_RESULT_OPS],
-    /// Input wires for the `MAX_NUM_RESULTS` output components that computes the
-    /// output values for the current row
-    output_component_wires: <T::Wires as OutputComponentWires>::InputWires,
+    hash_wires: UniversalQueryHashInputWires<MAX_NUM_COLUMNS, MAX_NUM_PREDICATE_OPS, MAX_NUM_RESULT_OPS, MAX_NUM_RESULTS, T>,
+    value_wires: UniversalQueryValueInputWires<MAX_NUM_COLUMNS>,
 }
 
-/// Trait for the 2 different variants of output components we currently support
-/// in query circuits
-pub trait OutputComponent<const MAX_NUM_RESULTS: usize>: Clone {
-    type Wires: OutputComponentWires;
-
-    fn new(selector: &[F], ids: &[F], num_outputs: usize) -> Result<Self>;
-
-    fn build<const NUM_OUTPUT_VALUES: usize>(
-        b: &mut CBuilder,
-        possible_output_values: [UInt256Target; NUM_OUTPUT_VALUES],
-        possible_output_hash: [ComputationalHashTarget; NUM_OUTPUT_VALUES],
-        predicate_value: &BoolTarget,
-        predicate_hash: &ComputationalHashTarget,
-    ) -> Self::Wires;
-
-    fn assign(
-        &self,
-        pw: &mut PartialWitness<F>,
-        wires: &<Self::Wires as OutputComponentWires>::InputWires,
-    );
-
-    /// Return the type of output component, specified as an instance of `Output` enum
-    fn output_variant() -> Output;
-}
-/// Trait representing the wires that need to be exposed by an `OutputComponent`
-/// employed in query circuits
-pub trait OutputComponentWires {
-    /// Associated type specifying the type of the first output value computed by this output
-    /// component; this type varies depending on the particular component:
-    /// - It is a `CurveTarget` in the output component for queries without aggregation operations
-    /// - It is a `UInt256Target` in the output for queries with aggregation operations
-    type FirstT: ToTargets;
-    /// Input wires of the output component
-    type InputWires: Serialize + for<'a> Deserialize<'a> + Clone + Debug + Eq + PartialEq;
-
-    /// Get the identifiers of the aggregation operations specified in the query to aggregate the
-    /// results (e.g., `SUM`, `AVG`)
-    fn ops_ids(&self) -> &[Target];
-    /// Get the first output value returned by the output component; this is accessed by an ad-hoc
-    /// method since such output value could be a `UInt256Target` or a `CurveTarget`, depending
-    /// on the output component instance
-    fn first_output_value(&self) -> Self::FirstT;
-    /// Get the subsequent output values returned by the output component
-    fn other_output_values(&self) -> &[UInt256Target];
-    /// Get the computational hash returned by the output component
-    fn computational_hash(&self) -> ComputationalHashTarget;
-    /// Get the input wires for the output component
-    fn input_wires(&self) -> Self::InputWires;
-}
 /// Witness input values for the universal query circuit
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct UniversalQueryCircuitInputs<
@@ -473,22 +34,11 @@ pub struct UniversalQueryCircuitInputs<
     const MAX_NUM_RESULT_OPS: usize,
     const MAX_NUM_RESULTS: usize,
     T: OutputComponent<MAX_NUM_RESULTS>,
-> {
-    column_extraction_inputs: ColumnExtractionInputs<MAX_NUM_COLUMNS>,
+> 
+{
     is_leaf: bool,
-    min_query: QueryBound,
-    max_query: QueryBound,
-    #[serde(
-        serialize_with = "serialize_long_array",
-        deserialize_with = "deserialize_long_array"
-    )]
-    filtering_predicate_inputs: [BasicOperationInputs; MAX_NUM_PREDICATE_OPS],
-    #[serde(
-        serialize_with = "serialize_long_array",
-        deserialize_with = "deserialize_long_array"
-    )]
-    result_values_inputs: [BasicOperationInputs; MAX_NUM_RESULT_OPS],
-    output_component_inputs: T,
+    hash_gadget_inputs: UniversalQueryHashInputs<MAX_NUM_COLUMNS, MAX_NUM_PREDICATE_OPS, MAX_NUM_RESULT_OPS, MAX_NUM_RESULTS, T>,
+    value_gadget_inputs: UniversalQueryValueInputs<MAX_NUM_COLUMNS, MAX_NUM_PREDICATE_OPS, MAX_NUM_RESULT_OPS, MAX_NUM_RESULTS>,
 }
 
 impl<
@@ -522,91 +72,26 @@ where
         query_bounds: &QueryBounds,
         results: &ResultStructure,
     ) -> Result<Self> {
-        let num_columns = row_cells.num_columns();
-        ensure!(
-            num_columns <= MAX_NUM_COLUMNS,
-            "number of columns is higher than the maximum value allowed"
-        );
-        let column_cells = row_cells.to_cells();
-        let padded_column_values = column_cells
-            .iter()
-            .map(|cell| cell.value)
-            .chain(repeat(U256::ZERO))
-            .take(MAX_NUM_COLUMNS)
-            .collect_vec();
-        let padded_column_ids = column_cells
-            .iter()
-            .map(|cell| cell.id)
-            .chain(repeat(F::NEG_ONE))
-            .take(MAX_NUM_COLUMNS)
-            .collect_vec();
-        let column_extraction_inputs = ColumnExtractionInputs::<MAX_NUM_COLUMNS> {
-            real_num_columns: num_columns,
-            column_values: padded_column_values.try_into().unwrap(),
-            column_ids: padded_column_ids.try_into().unwrap(),
-        };
-        let num_predicate_ops = predicate_operations.len();
-        ensure!(num_predicate_ops <= MAX_NUM_PREDICATE_OPS,
-            "Number of operations to compute filtering predicate is higher than the maximum number allowed");
-        let num_result_ops = results.result_operations.len();
-        ensure!(
-            num_result_ops <= MAX_NUM_RESULT_OPS,
-            "Number of operations to compute results is higher than the maximum number allowed"
-        );
-        let predicate_ops_inputs = Self::compute_operation_inputs::<MAX_NUM_PREDICATE_OPS>(
+        let hash_gadget_inputs = UniversalQueryHashInputs::new(
+            &row_cells.column_ids(),
             predicate_operations,
             placeholders,
-        )?;
-        let result_ops_inputs = Self::compute_operation_inputs::<MAX_NUM_RESULT_OPS>(
-            &results.result_operations,
-            placeholders,
-        )?;
-        let selectors = results.output_items.iter().enumerate().map(|(i, item)| {
-            Ok(
-                match item {
-                    OutputItem::Column(index) => {
-                        ensure!(*index < MAX_NUM_COLUMNS,
-                        "Column index provided as {}-th output value is higher than the maximum number of columns", i);
-                    F::from_canonical_usize(*index)
-                    },
-                    OutputItem::ComputedValue(index) => {
-                        ensure!(*index < num_result_ops,
-                            "an operation computing an output results not found in set of result operations");
-                        // the output will be placed in the `num_result_ops - index` last slot in the set of
-                        // `possible_output_values` provided as input in the circuit to the output component,
-                        // i.e., the input array found in `OutputComponent::build` method.
-                        // Therefore, since the `possible_output_values` array in the circuit has
-                        // `MAX_NUM_COLUMNS + MAX_NUM_RESULT_OPS` entries, the selector for such output value
-                        // can be computed as the length of `possible_output_values.len() - (num_result_ops - index)`,
-                        // which correspond to the `num_result_ops - index`-th entry from the end of the array
-                        F::from_canonical_usize(MAX_NUM_COLUMNS + MAX_NUM_RESULT_OPS - (num_result_ops - *index))
-                    },
-            })
-        }).collect::<Result<Vec<_>>>()?;
-        let output_component_inputs =
-            T::new(&selectors, &results.output_ids, results.output_ids.len())?;
-
-        let min_query = QueryBound::new_secondary_index_bound(
-            &placeholders,
-            &query_bounds.min_query_secondary(),
+            query_bounds,
+            results
         )?;
 
-        let max_query = QueryBound::new_secondary_index_bound(
-            &placeholders,
-            &query_bounds.max_query_secondary(),
+        let value_gadget_inputs = UniversalQueryValueInputs::new(
+            row_cells,
+            true,
         )?;
-
+        
         Ok(Self {
-            column_extraction_inputs,
             is_leaf,
-            min_query,
-            max_query,
-            filtering_predicate_inputs: predicate_ops_inputs,
-            result_values_inputs: result_ops_inputs,
-            output_component_inputs,
+            hash_gadget_inputs,
+            value_gadget_inputs,
         })
     }
-
+    
     pub(crate) fn build(
         b: &mut CircuitBuilder<F, D>,
     ) -> UniversalQueryCircuitWires<
@@ -616,20 +101,29 @@ where
         MAX_NUM_RESULTS,
         T,
     > {
-        let column_extraction_wires = ColumnExtractionInputs::<MAX_NUM_COLUMNS>::build(b);
+        let hash_wires = UniversalQueryHashInputs::build(b);
+        let value_wires = UniversalQueryValueInputs::build(
+            b,
+            &hash_wires.input_wires,
+            &hash_wires.min_secondary,
+            &hash_wires.max_secondary,
+            None,
+            None,
+            &hash_wires.num_bound_overflows,
+        );
         let is_leaf = b.add_virtual_bool_target_safe();
         let _true = b._true();
         let zero = b.zero();
         // min and max for secondary indexed column
-        let node_min = &column_extraction_wires.input_wires.column_values[1];
+        let node_min = &value_wires.input_wires.column_values[1];
         let node_max = node_min;
+        // value of the primary indexed column
+        let index_value = &value_wires.input_wires.column_values[0];
         // column ids for primary and seconday indexed columns
         let (primary_index_id, second_index_id) = (
-            &column_extraction_wires.input_wires.column_ids[0],
-            &column_extraction_wires.input_wires.column_ids[1],
+            &hash_wires.input_wires.column_extraction_wires.column_ids[0],
+            &hash_wires.input_wires.column_extraction_wires.column_ids[1],
         );
-        // value of the primary indexed column for the current row
-        let index_value = &column_extraction_wires.input_wires.column_values[0];
         // compute hash of the node in case the current row is stored in a leaf of the rows tree
         let empty_hash = b.constant_hash(*empty_poseidon_hash());
         let leaf_hash_inputs = empty_hash
@@ -640,165 +134,38 @@ where
             .chain(node_max.to_targets().iter())
             .chain(once(second_index_id))
             .chain(node_min.to_targets().iter())
-            .chain(column_extraction_wires.tree_hash.elements.iter())
+            .chain(value_wires.output_wires.tree_hash.elements.iter())
             .cloned()
             .collect();
         let leaf_hash = b.hash_n_to_hash_no_pad::<CHasher>(leaf_hash_inputs);
-        let tree_hash = b.select_hash(is_leaf, &leaf_hash, &column_extraction_wires.tree_hash);
-        // ensure that the value of second indexed column for the current record is in
-        // the range specified by the query
-        let min_query = QueryBoundTarget::new(b);
-        let max_query = QueryBoundTarget::new(b);
-        let min_query_value = min_query.get_bound_value();
-        let max_query_value = max_query.get_bound_value();
-        let less_than_max = b.is_less_or_equal_than_u256(node_max, max_query_value);
-        let greater_than_min = b.is_less_or_equal_than_u256(min_query_value, node_min);
-        b.connect(less_than_max.target, _true.target);
-        b.connect(greater_than_min.target, _true.target);
-        // initialize input_values and input_hash input vectors for basic operation components employed to
-        // evaluate the filtering predicate
-        let mut input_values = column_extraction_wires.input_wires.column_values.to_vec();
-        let mut input_hash = column_extraction_wires.column_hash.to_vec();
-        // Set of input wires for each of the `MAX_NUM_PREDICATE_OPS` basic operation components employed to
-        // evaluate the filtering predicate
-        let mut filtering_predicate_wires = Vec::with_capacity(MAX_NUM_PREDICATE_OPS);
-        // Payload to compute the placeholder hash public input
-        let mut placeholder_hash_payload = vec![];
-        // initialize counter of overflows to number of overflows occurred during query bound operations
-        let mut num_overflows =
-            QueryBoundTarget::num_overflows_for_query_bound_operations(b, &min_query, &max_query);
-
-        for _ in 0..MAX_NUM_PREDICATE_OPS {
-            let BasicOperationWires {
-                input_wires,
-                output_value,
-                output_hash,
-                num_overflows: new_num_overflows,
-            } = BasicOperationInputs::build(b, &input_values, &input_hash, num_overflows);
-            // add the output_value computed by the last basic operation component to the input values
-            // for the next basic operation components employed to evaluate the filtering predicate
-            input_values.push(output_value);
-            // and the corresponding output_hash to the input hash as well
-            input_hash.push(output_hash);
-            // update the counter of overflows detected
-            num_overflows = new_num_overflows;
-            // add placeholder data to payload for placeholder hash
-            placeholder_hash_payload.push(input_wires.placeholder_ids[0]);
-            placeholder_hash_payload
-                .extend_from_slice(&input_wires.placeholder_values[0].to_targets());
-            placeholder_hash_payload.push(input_wires.placeholder_ids[1]);
-            placeholder_hash_payload
-                .extend_from_slice(&input_wires.placeholder_values[1].to_targets());
-            filtering_predicate_wires.push(input_wires);
-        }
-        // Place the evaluation of the filtering predicate, and the corresponding computational hash, in
-        // two variables; the evaluation and the corresponding hash are expected to be the output of the
-        // last basic operation component among the `MAX_NUM_PREDICATE_OPS` ones employed to evaluate
-        // the filtering predicate. This placement is done in order to have a fixed slot where we can
-        // find the predicate value, without the need for a further random_access operation just to extract
-        // this value from the set of predicate operations
-        let predicate_value = input_values.last().unwrap().to_bool_target();
-        let predicate_hash = input_hash.last().unwrap();
-        // initialize input_values and input_hash input vectors for basic operation components employed to
-        // compute the results to be returned for the current row
-        let mut input_values = column_extraction_wires.input_wires.column_values.to_vec();
-        let mut input_hash = column_extraction_wires.column_hash.to_vec();
-        // Set of input wires for each of the `MAX_NUM_RESULT_OPS` basic operation components employed to
-        // compute the results to be returned for the current row
-        let mut result_value_wires = Vec::with_capacity(MAX_NUM_RESULT_OPS);
-        for _ in 0..MAX_NUM_RESULT_OPS {
-            let BasicOperationWires {
-                input_wires,
-                output_value,
-                output_hash,
-                num_overflows: new_num_overflows,
-            } = BasicOperationInputs::build(b, &input_values, &input_hash, num_overflows);
-            // add the output_value computed by the last basic operation component to the input values
-            // for the next basic operation components employed to compute results for current row
-            input_values.push(output_value);
-            // and the corresponding output_hash to the input hash as well
-            input_hash.push(output_hash);
-            // update the counter of overflows detected
-            num_overflows = new_num_overflows;
-            // add placeholder data to payload for placeholder hash
-            placeholder_hash_payload.push(input_wires.placeholder_ids[0]);
-            placeholder_hash_payload
-                .extend_from_slice(&input_wires.placeholder_values[0].to_targets());
-            placeholder_hash_payload.push(input_wires.placeholder_ids[1]);
-            placeholder_hash_payload
-                .extend_from_slice(&input_wires.placeholder_values[1].to_targets());
-            result_value_wires.push(input_wires);
-        }
-        // `possible_output_values` to be provided to output component are the set of `MAX_NUM_COLUMNS`
-        // and the `MAX_NUM_RESULT_OPS` results of results operations, which are all already accumulated
-        // in the `input_values` vector
-        let possible_output_values: [UInt256Target; MAX_NUM_COLUMNS + MAX_NUM_RESULT_OPS] =
-            input_values.try_into().unwrap();
-        // same for `possible_output_hash`, all the hashes are already accumulated in the `input_hash` vector
-        let possible_output_hash: [ComputationalHashTarget; MAX_NUM_COLUMNS + MAX_NUM_RESULT_OPS] =
-            input_hash.try_into().unwrap();
-        let output_component_wires = T::build(
-            b,
-            possible_output_values,
-            possible_output_hash,
-            &predicate_value,
-            predicate_hash,
-        );
+        let tree_hash = b.select_hash(is_leaf, &leaf_hash, &value_wires.output_wires.tree_hash);
+        
         // compute overflow flag
-        let not_overflow = b.is_equal(num_overflows, zero);
-        let overflow = b.not(not_overflow);
-        let placeholder_hash = b.hash_n_to_hash_no_pad::<CHasher>(placeholder_hash_payload);
-        let placeholder_hash = QueryBoundTarget::add_query_bounds_to_placeholder_hash(
-            b,
-            &min_query,
-            &max_query,
-            &placeholder_hash,
-        );
-        // compute output_values to be exposed; we call `pad_slice_to_curve_len` to ensure that the
-        // first output value is always padded to the size of a `CurveTarget`
-        let mut output_values = PublicInputs::<_, MAX_NUM_RESULTS>::pad_slice_to_curve_len(
-            &output_component_wires.first_output_value().to_targets(),
-        );
-        // Append the other `MAX_NUM_RESULTS-1` output values
-        output_values.extend_from_slice(
-            &output_component_wires
-                .other_output_values()
-                .iter()
-                .flat_map(|t| t.to_targets())
-                .collect_vec(),
-        );
-        // add query bounds to computational hash
-        let computational_hash = QueryBoundTarget::add_query_bounds_to_computational_hash(
-            b,
-            &min_query,
-            &max_query,
-            &output_component_wires.computational_hash(),
-        );
+        let overflow = b.is_not_equal(value_wires.output_wires.num_overflows, zero);
+
+        let output_values_targets = value_wires.output_wires.values.into_iter().flatten().collect_vec();
+        
         PublicInputs::<Target, MAX_NUM_RESULTS>::new(
             &tree_hash.to_targets(),
-            output_values.as_slice(),
-            &[predicate_value.target],
-            output_component_wires.ops_ids(),
+            &output_values_targets,
+            &[value_wires.output_wires.count],
+            hash_wires.agg_ops_ids.as_slice(),
             &index_value.to_targets(),
             &node_min.to_targets(),
             &node_max.to_targets(),
             &[*primary_index_id, *second_index_id],
-            &min_query_value.to_targets(),
-            &max_query_value.to_targets(),
+            &hash_wires.min_secondary.to_targets(),
+            &hash_wires.max_secondary.to_targets(),
             &[overflow.target],
-            &computational_hash.to_targets(),
-            &placeholder_hash.to_targets(),
+            &hash_wires.computational_hash.to_targets(),
+            &hash_wires.placeholder_hash.to_targets(),
         )
         .register(b);
 
         UniversalQueryCircuitWires {
-            column_extraction_wires: column_extraction_wires.input_wires,
             is_leaf,
-            min_query: min_query.into(),
-            max_query: max_query.into(),
-            filtering_predicate_ops: filtering_predicate_wires.try_into().unwrap(),
-            result_value_ops: result_value_wires.try_into().unwrap(),
-            output_component_wires: output_component_wires.input_wires(),
+            hash_wires: hash_wires.input_wires,
+            value_wires: value_wires.input_wires,
         }
     }
 
@@ -813,35 +180,16 @@ where
             T,
         >,
     ) {
-        self.column_extraction_inputs
-            .assign(pw, &wires.column_extraction_wires);
         pw.set_bool_target(wires.is_leaf, self.is_leaf);
-        wires.min_query.assign(pw, &self.min_query);
-        wires.max_query.assign(pw, &self.max_query);
-        self.filtering_predicate_inputs
-            .iter()
-            .zip(wires.filtering_predicate_ops.iter())
-            .for_each(|(inputs, wires)| inputs.assign(pw, wires));
-        self.result_values_inputs
-            .iter()
-            .zip(wires.result_value_ops.iter())
-            .for_each(|(inputs, wires)| inputs.assign(pw, wires));
-        self.output_component_inputs
-            .assign(pw, &wires.output_component_wires);
+        self.hash_gadget_inputs.assign(pw, &wires.hash_wires);
+        self.value_gadget_inputs.assign(pw, &wires.value_wires);
     }
 
     /// This method returns the ids of the placeholders employed to compute the placeholder hash,
     /// in the same order, so that those ids can be provided as input to other circuits that need
     /// to recompute this hash
     pub(crate) fn ids_for_placeholder_hash(&self) -> Vec<PlaceholderId> {
-        self.filtering_predicate_inputs
-            .iter()
-            .flat_map(|op_inputs| vec![op_inputs.placeholder_ids[0], op_inputs.placeholder_ids[1]])
-            .chain(self.result_values_inputs.iter().flat_map(|op_inputs| {
-                vec![op_inputs.placeholder_ids[0], op_inputs.placeholder_ids[1]]
-            }))
-            .map(|id| PlaceholderIdentifier::from_fields(&[id]))
-            .collect_vec()
+        self.hash_gadget_inputs.ids_for_placeholder_hash()
     }
 
     /// Utility function to compute the `BasicOperationInputs` corresponding to the set of `operations` specified
@@ -851,128 +199,14 @@ where
         operations: &[BasicOperation],
         placeholders: &Placeholders,
     ) -> Result<[BasicOperationInputs; MAX_NUM_OPS]> {
-        let dummy_placeholder = dummy_placeholder(placeholders);
-        // starting offset in the input values provided to basic operation component where the output values
-        // of `operations` will be found. It is computed as follows since these operations will be placed
-        // at the end of these functions in the last slots among the `MAX_NUM_OPS` available, as expected
-        // by the circuit
-        let start_actual_ops = MAX_NUM_COLUMNS + MAX_NUM_OPS - operations.len();
-        let ops_wires = operations.iter().enumerate().map(|(i, op)| {
-            let mut constant_operand = U256::ZERO;
-            // the number of input values provided to the basic operation component
-            // computing the current predicate operation
-            let num_inputs = start_actual_ops + i;
-            let mut compute_op_inputs = |is_first_op: bool| {
-                let operand = if is_first_op {
-                    op.first_operand
-                } else {
-                    op.second_operand.unwrap_or_default()
-                };
-                Ok(
-                match operand {
-                    InputOperand::Placeholder(p) => {
-                        let placeholder_value = placeholders.get(&p)?;
-                        (
-                            Some(placeholder_value),
-                            Some(p),
-                            if is_first_op {
-                                BasicOperationInputs::first_placeholder_offset(num_inputs)
-                            } else {
-                                BasicOperationInputs::second_placeholder_offset(num_inputs)
-                            },
-                        )
-                    },
-                    InputOperand::Constant(val) => {
-                        constant_operand = val;
-                        (
-                            None,
-                            None,
-                            BasicOperationInputs::constant_operand_offset(num_inputs),
-                        )
-                    },
-                    InputOperand::Column(index) => {
-                        ensure!(index < MAX_NUM_COLUMNS,
-                            "column index specified as input for {}-th predicate operation is higher than number of columns", i);
-                        (
-                            None,
-                            None,
-                            BasicOperationInputs::input_value_offset(index),
-                        )
-                    },
-                    InputOperand::PreviousValue(index) => {
-                        ensure!(index < i,
-                            "previous value index specified as input for {}-th predicate operation is higher than the number of values already computed by previous operations", i);
-                        (
-                            None,
-                            None,
-                            BasicOperationInputs::input_value_offset(start_actual_ops+index),
-                        )
-                    },
-                }
-            )};
-            let (first_placeholder_value, first_placeholder_id, first_selector) = compute_op_inputs(
-                true
-            )?;
-            let (second_placeholder_value, second_placeholder_id, second_selector) = compute_op_inputs(
-                false
-            )?;
-            let placeholder_values = [
-                first_placeholder_value.unwrap_or(dummy_placeholder.value),
-                second_placeholder_value.unwrap_or(dummy_placeholder.value)
-            ];
-            let placeholder_ids = [
-                first_placeholder_id.unwrap_or(dummy_placeholder.id).to_field(),
-                second_placeholder_id.unwrap_or(dummy_placeholder.id).to_field(),
-            ];
-            Ok(BasicOperationInputs {
-                constant_operand,
-                placeholder_values,
-                placeholder_ids,
-                first_input_selector: F::from_canonical_usize(first_selector),
-                second_input_selector: F::from_canonical_usize(second_selector),
-                op_selector: op.op.to_field(),
-            })
-        }).collect::<Result<Vec<_>>>()?;
-        // we pad ops_wires up to `MAX_NUM_OPS` with dummy operations; we pad at
-        // the beginning of the array since the circuits expects to find the operation computing
-        // the actual result values as the last of the `MAX_NUM_OPS` operations
-        Ok(repeat(
-            // dummy operation
-            BasicOperationInputs {
-                constant_operand: U256::ZERO,
-                placeholder_values: [dummy_placeholder.value, dummy_placeholder.value],
-                placeholder_ids: [
-                    dummy_placeholder.id.to_field(),
-                    dummy_placeholder.id.to_field(),
-                ],
-                first_input_selector: F::ZERO,
-                second_input_selector: F::ZERO,
-                op_selector: Operation::EqOp.to_field(),
-            },
-        )
-        .take(MAX_NUM_OPS - operations.len())
-        .chain(ops_wires)
-        .collect_vec()
-        .try_into()
-        .unwrap())
+        UniversalQueryHashInputs::<
+            MAX_NUM_COLUMNS,
+            MAX_NUM_PREDICATE_OPS,
+            MAX_NUM_RESULT_OPS,
+            MAX_NUM_RESULTS,
+            T,
+        >::compute_operation_inputs(operations, placeholders)
     }
-}
-
-/// Placeholder to be employed in the universal circuit as a dummy placeholder
-/// in the circuit
-fn dummy_placeholder(placeholders: &Placeholders) -> Placeholder {
-    Placeholder {
-        value: placeholders.get(&dummy_placeholder_id()).unwrap(), // cannot fail since default placeholder is always associated to a value
-        id: dummy_placeholder_id(),
-    }
-}
-
-fn dummy_placeholder_from_query_bounds(query_bounds: &QueryBounds) -> Placeholder {
-    let placeholders = Placeholders::new_empty(
-        query_bounds.min_query_primary(),
-        query_bounds.max_query_primary(),
-    );
-    dummy_placeholder(&placeholders)
 }
 
 pub(crate) fn dummy_placeholder_id() -> PlaceholderId {
@@ -1023,7 +257,7 @@ impl<
         const MAX_NUM_PREDICATE_OPS: usize,
         const MAX_NUM_RESULT_OPS: usize,
         const MAX_NUM_RESULTS: usize,
-        T: OutputComponent<MAX_NUM_RESULTS>,
+        T: OutputComponent<MAX_NUM_RESULTS> + Serialize + DeserializeOwned,
     > CircuitLogicWires<F, D, 0>
     for UniversalQueryCircuitWires<
         MAX_NUM_COLUMNS,
@@ -1147,6 +381,7 @@ where
         ))
     }
 }
+
 
 #[cfg(test)]
 mod tests {

--- a/verifiable-db/src/revelation/api.rs
+++ b/verifiable-db/src/revelation/api.rs
@@ -34,7 +34,6 @@ use crate::{
             universal_circuit_inputs::{
                 BasicOperation, PlaceholderId, Placeholders, ResultStructure,
             },
-            universal_query_circuit::QueryBound,
         },
         PI_LEN as QUERY_PI_LEN,
     },

--- a/verifiable-db/src/revelation/api.rs
+++ b/verifiable-db/src/revelation/api.rs
@@ -396,13 +396,8 @@ where
         )?;
         let placeholder_inputs =
             CheckPlaceholderGadget::new(query_bounds, placeholders, placeholder_hash_ids)?;
-        let index_ids = [
-            column_ids.primary.to_canonical_u64(),
-            column_ids.secondary.to_canonical_u64(),
-        ];
         let revelation_circuit = RevelationCircuitUnprovenOffset::new(
             row_paths,
-            index_ids,
             &results_structure.output_ids,
             result_values,
             limit,

--- a/verifiable-db/src/revelation/api.rs
+++ b/verifiable-db/src/revelation/api.rs
@@ -30,10 +30,8 @@ use crate::{
         aggregation::QueryBounds,
         api::{CircuitInput as QueryCircuitInput, Parameters as QueryParams},
         computational_hash_ids::{ColumnIDs, PlaceholderIdentifier},
-        universal_circuit::{
-            universal_circuit_inputs::{
-                BasicOperation, PlaceholderId, Placeholders, ResultStructure,
-            },
+        universal_circuit::universal_circuit_inputs::{
+            BasicOperation, PlaceholderId, Placeholders, ResultStructure,
         },
         PI_LEN as QUERY_PI_LEN,
     },

--- a/verifiable-db/src/revelation/placeholders_check.rs
+++ b/verifiable-db/src/revelation/placeholders_check.rs
@@ -6,7 +6,7 @@ use crate::query::{
     computational_hash_ids::PlaceholderIdentifier,
     universal_circuit::{
         universal_circuit_inputs::{PlaceholderId, Placeholders},
-        universal_query_circuit::QueryBound,
+        universal_query_gadget::QueryBound,
     },
 };
 use alloy::primitives::U256;

--- a/verifiable-db/src/revelation/revelation_unproven_offset.rs
+++ b/verifiable-db/src/revelation/revelation_unproven_offset.rs
@@ -289,7 +289,6 @@ where
 {
     pub(crate) fn new(
         row_paths: [RowPath; L],
-        index_ids: [u64; 2],
         item_ids: &[F],
         results: [Vec<U256>; L],
         limit: u64,
@@ -302,13 +301,9 @@ where
         let mut row_node_info = [NodeInfo::default(); L];
         let mut index_node_info = [NodeInfo::default(); L];
         for (i, row) in row_paths.into_iter().enumerate() {
-            row_tree_paths[i] =
-                MerklePathGadget::new(&row.row_tree_path, &row.row_path_siblings, index_ids[1])?;
-            index_tree_paths[i] = MerklePathGadget::new(
-                &row.index_tree_path,
-                &row.index_path_siblings,
-                index_ids[0],
-            )?;
+            row_tree_paths[i] = MerklePathGadget::new(&row.row_tree_path, &row.row_path_siblings)?;
+            index_tree_paths[i] =
+                MerklePathGadget::new(&row.index_tree_path, &row.index_path_siblings)?;
             row_node_info[i] = row.row_node_info;
             index_node_info[i] = row.index_node_info;
         }
@@ -1263,12 +1258,6 @@ mod tests {
             TestRevelationCircuit::<ROW_TREE_MAX_DEPTH, INDEX_TREE_MAX_DEPTH, L, S, PH, PP> {
                 circuit: RevelationCircuit::new(
                     [row_path_0, row_path_1, row_path_2, row_path_3, row_path_4],
-                    index_ids
-                        .into_iter()
-                        .map(|id| id.to_canonical_u64())
-                        .collect_vec()
-                        .try_into()
-                        .unwrap(),
                     &ids,
                     results.map(|res| res.to_vec()),
                     0,


### PR DESCRIPTION
First PR for batching query circuits. It provides:

- The gadget for Merkle-path verification that also locates predecessor and successor nodes in the BST
- A refactoring of universal query circuit logic in 2 components, `universal_query_hash_gadget` and `universal_query_value_gadget`, which will then be employed distinctly in the new batching circuits