### PR TITLE
Add `TableRowUpdate` capabilities for receipts

### DIFF
--- a/mp2-common/src/eth.rs
+++ b/mp2-common/src/eth.rs
@@ -382,7 +382,7 @@ impl ReceiptProofInfo {
             .verify_proof(self.mpt_root, &mpt_key, self.mpt_proof.clone())?
             .ok_or(anyhow!("No proof found when verifying"))?;
 
-        let rlp_receipt = rlp::Rlp::new(&valid[1..]);
+        let rlp_receipt = rlp::Rlp::new(&valid[..]);
         ReceiptWithBloom::decode(&mut rlp_receipt.as_raw())
             .map_err(|e| anyhow!("Could not decode receipt got: {}", e))
     }

--- a/mp2-v1/src/indexing/cell.rs
+++ b/mp2-v1/src/indexing/cell.rs
@@ -57,7 +57,9 @@ pub async fn new_tree<
 
 /// Cell is the information stored in a specific cell of a specific row.
 /// A row node in the row tree contains a vector of such cells.
-#[derive(Clone, Default, Debug, Serialize, Deserialize, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(
+    Clone, Copy, Default, Debug, Serialize, Deserialize, Hash, PartialEq, Eq, PartialOrd, Ord,
+)]
 pub struct Cell {
     /// The unique identifier of the cell, derived from the contract it comes
     /// from and its slot in its storage.

--- a/mp2-v1/src/values_extraction/api.rs
+++ b/mp2-v1/src/values_extraction/api.rs
@@ -13,7 +13,7 @@ use anyhow::{bail, ensure, Result};
 use log::debug;
 use mp2_common::{
     default_config,
-    eth::{ReceiptProofInfo, ReceiptQuery},
+    eth::{EventLogInfo, ReceiptProofInfo},
     mpt_sequential::PAD_LEN,
     proof::{ProofInputSerialized, ProofWithVK},
     storage_key::{MappingSlot, SimpleSlot},
@@ -80,10 +80,10 @@ impl CircuitInput {
     /// Create a circuit input for proving a leaf MPT node of a transaction receipt.
     pub fn new_receipt_leaf<const NO_TOPICS: usize, const MAX_DATA: usize>(
         info: &ReceiptProofInfo,
-        query: &ReceiptQuery<NO_TOPICS, MAX_DATA>,
+        event: &EventLogInfo<NO_TOPICS, MAX_DATA>,
     ) -> Self {
         CircuitInput::LeafReceipt(
-            ReceiptLeafCircuit::new(info, query).expect("Could not construct Receipt Leaf Circuit"),
+            ReceiptLeafCircuit::new(info, event).expect("Could not construct Receipt Leaf Circuit"),
         )
     }
 
@@ -750,7 +750,7 @@ mod tests {
         let params = build_circuits_params();
 
         println!("Proving leaf 1...");
-        let leaf_input_1 = CircuitInput::new_receipt_leaf(info_one, query);
+        let leaf_input_1 = CircuitInput::new_receipt_leaf(info_one, &query.event);
         let now = std::time::Instant::now();
         let leaf_proof1 = generate_proof(&params, leaf_input_1).unwrap();
         {
@@ -765,7 +765,7 @@ mod tests {
         );
 
         println!("Proving leaf 2...");
-        let leaf_input_2 = CircuitInput::new_receipt_leaf(info_two, query);
+        let leaf_input_2 = CircuitInput::new_receipt_leaf(info_two, &query.event);
         let now = std::time::Instant::now();
         let leaf_proof2 = generate_proof(&params, leaf_input_2).unwrap();
         println!(

--- a/mp2-v1/src/values_extraction/planner.rs
+++ b/mp2-v1/src/values_extraction/planner.rs
@@ -1,0 +1,123 @@
+//! This code returns an [`UpdateTree`] used to plan how we prove a series of values was extracted from a Merkle Patricia Trie.
+use alloy::{
+    network::Ethereum,
+    primitives::{keccak256, Address, B256},
+    providers::RootProvider,
+    transports::Transport,
+};
+use anyhow::Result;
+use mp2_common::eth::{EventLogInfo, ReceiptQuery};
+use ryhope::storage::updatetree::UpdateTree;
+use std::future::Future;
+
+/// Trait that is implemented for all data that we can provably extract.
+pub trait Extractable {
+    fn create_update_tree<T: Transport + Clone>(
+        &self,
+        contract: Address,
+        epoch: u64,
+        provider: &RootProvider<T, Ethereum>,
+    ) -> impl Future<Output = Result<UpdateTree<B256>>>;
+}
+
+impl<const NO_TOPICS: usize, const MAX_DATA: usize> Extractable
+    for EventLogInfo<NO_TOPICS, MAX_DATA>
+{
+    async fn create_update_tree<T: Transport + Clone>(
+        &self,
+        contract: Address,
+        epoch: u64,
+        provider: &RootProvider<T, Ethereum>,
+    ) -> Result<UpdateTree<B256>> {
+        let query = ReceiptQuery::<NO_TOPICS, MAX_DATA> {
+            contract,
+            event: *self,
+        };
+
+        let proofs = query.query_receipt_proofs(provider, epoch.into()).await?;
+
+        // Convert the paths into their keys using keccak
+        let key_paths = proofs
+            .iter()
+            .map(|input| input.mpt_proof.iter().map(keccak256).collect::<Vec<B256>>())
+            .collect::<Vec<Vec<B256>>>();
+
+        // Now we make the UpdateTree
+        Ok(UpdateTree::<B256>::from_paths(key_paths, epoch as i64))
+    }
+}
+
+#[cfg(test)]
+pub mod tests {
+
+    use alloy::{eips::BlockNumberOrTag, primitives::Address, providers::ProviderBuilder, sol};
+    use anyhow::anyhow;
+    use mp2_common::eth::BlockUtil;
+    use mp2_test::eth::get_mainnet_url;
+    use std::str::FromStr;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_receipt_update_tree() -> Result<()> {
+        // First get the info we will feed in to our function
+        let event_info = test_receipt_trie_helper().await?;
+
+        let contract = Address::from_str("0xbd3531da5cf5857e7cfaa92426877b022e612cf8")?;
+        let epoch: u64 = 21362445;
+
+        let url = get_mainnet_url();
+        // get some tx and receipt
+        let provider = ProviderBuilder::new().on_http(url.parse().unwrap());
+
+        let update_tree = event_info
+            .create_update_tree(contract, epoch, &provider)
+            .await?;
+
+        let block_util = build_test_data().await;
+
+        assert_eq!(*update_tree.root(), block_util.block.header.receipts_root);
+        Ok(())
+    }
+
+    /// Function that fetches a block together with its transaction trie and receipt trie for testing purposes.
+    async fn build_test_data() -> BlockUtil {
+        let url = get_mainnet_url();
+        // get some tx and receipt
+        let provider = ProviderBuilder::new().on_http(url.parse().unwrap());
+
+        // We fetch a specific block which we know includes transactions relating to the PudgyPenguins contract.
+        BlockUtil::fetch(&provider, BlockNumberOrTag::Number(21362445))
+            .await
+            .unwrap()
+    }
+
+    /// Function to build a list of [`ReceiptProofInfo`] for a set block.
+    async fn test_receipt_trie_helper() -> Result<EventLogInfo<2, 1>> {
+        // First we choose the contract and event we are going to monitor.
+        // We use the mainnet PudgyPenguins contract at address 0xbd3531da5cf5857e7cfaa92426877b022e612cf8
+        // and monitor for the `Approval` event.
+        let address = Address::from_str("0xbd3531da5cf5857e7cfaa92426877b022e612cf8")?;
+
+        // We have to create what the event abi looks like
+        sol! {
+            #[allow(missing_docs)]
+            #[sol(rpc, abi)]
+            contract EventTest {
+            #[derive(Debug)]
+            event ApprovalForAll(address indexed owner, address indexed operator, bool approved);
+
+            }
+        };
+
+        let approval_event = EventTest::abi::events()
+            .get("ApprovalForAll")
+            .ok_or(anyhow!("No ApprovalForAll event exists"))?[0]
+            .clone();
+
+        Ok(EventLogInfo::<2, 1>::new(
+            address,
+            &approval_event.signature(),
+        ))
+    }
+}

--- a/mp2-v1/tests/common/cases/indexing.rs
+++ b/mp2-v1/tests/common/cases/indexing.rs
@@ -1091,7 +1091,7 @@ impl<PrimaryIndex: Clone + Default + PartialEq + Eq> TableRowValues<PrimaryIndex
                     .expect("missing cell");
                 if new.value() != current.value() {
                     // there is an update!
-                    Some(new.clone())
+                    Some(*new)
                 } else {
                     None
                 }

--- a/mp2-v1/tests/common/cases/table_source.rs
+++ b/mp2-v1/tests/common/cases/table_source.rs
@@ -1,5 +1,6 @@
 use std::{
     assert_matches::assert_matches,
+    collections::HashMap,
     fmt::Debug,
     future::Future,
     hash::Hash,
@@ -8,6 +9,7 @@ use std::{
 };
 
 use alloy::{
+    consensus::TxReceipt,
     eips::BlockNumberOrTag,
     primitives::{Address, U256},
     providers::{Provider, ProviderBuilder},
@@ -17,7 +19,7 @@ use futures::{future::BoxFuture, FutureExt};
 use log::{debug, info};
 use mp2_common::{
     digest::TableDimension,
-    eth::{EventLogInfo, ProofQuery, StorageSlot},
+    eth::{EventLogInfo, ProofQuery, ReceiptProofInfo, ReceiptQuery, StorageSlot},
     poseidon::H,
     proof::ProofWithVK,
     types::{GFp, HashOutput},
@@ -30,10 +32,12 @@ use mp2_v1::{
         row::{RowTreeKey, ToNonce},
     },
     values_extraction::{
-        compute_receipt_leaf_metadata_digest, identifier_for_mapping_key_column,
-        identifier_for_mapping_value_column, identifier_single_var_column,
+        compute_all_receipt_coulmn_ids, compute_receipt_leaf_metadata_digest,
+        identifier_for_mapping_key_column, identifier_for_mapping_value_column,
+        identifier_single_var_column,
     },
 };
+use plonky2::field::types::PrimeField64;
 use rand::{Rng, SeedableRng};
 use serde::{Deserialize, Serialize};
 
@@ -1132,6 +1136,96 @@ pub trait ReceiptExtractionArgs:
     fn get_event(&self) -> EventLogInfo<{ Self::NO_TOPICS }, { Self::MAX_DATA }>;
 
     fn get_index(&self) -> u64;
+
+    fn to_table_rows<PrimaryIndex: Copy>(
+        proof_infos: &[ReceiptProofInfo],
+        event: &EventLogInfo<{ Self::NO_TOPICS }, { Self::MAX_DATA }>,
+        block: PrimaryIndex,
+    ) -> Vec<TableRowUpdate<PrimaryIndex>> {
+        let column_ids = HashMap::<String, u64>::from_iter(
+            compute_all_receipt_coulmn_ids(event)
+                .into_iter()
+                .map(|(name, field)| (name, field.to_canonical_u64())),
+        );
+
+        proof_infos
+            .iter()
+            .flat_map(|info| {
+                let receipt_with_bloom = info.to_receipt().unwrap();
+
+                let tx_index_cell = Cell::new(
+                    *column_ids.get("tx index").unwrap(),
+                    U256::from(info.tx_index),
+                );
+
+                let gas_used_cell = Cell::new(
+                    *column_ids.get("gas used").unwrap(),
+                    U256::from(receipt_with_bloom.receipt.cumulative_gas_used),
+                );
+
+                receipt_with_bloom
+                    .logs()
+                    .iter()
+                    .filter_map(|log| {
+                        if log.address == event.address
+                            && log.topics()[0].0 == event.event_signature
+                        {
+                            Some(log.clone())
+                        } else {
+                            None
+                        }
+                    })
+                    .enumerate()
+                    .map(|(log_no, log)| {
+                        let log_no_cell = Cell::new(
+                            *column_ids.get("log number").unwrap(),
+                            U256::from(log_no as u8 + 1),
+                        );
+
+                        let (topics, data) = log.data.split();
+                        let topics_cells = topics
+                            .into_iter()
+                            .enumerate()
+                            .skip(1)
+                            .map(|(j, topic)| {
+                                Cell::new(
+                                    *column_ids.get(&format!("topic_{}", j)).unwrap(),
+                                    topic.into(),
+                                )
+                            })
+                            .collect::<Vec<Cell>>();
+
+                        let data_cells = data
+                            .chunks(32)
+                            .enumerate()
+                            .map(|(j, data_slice)| {
+                                Cell::new(
+                                    *column_ids.get(&format!("data_{}", j + 1)).unwrap(),
+                                    U256::from_be_slice(data_slice),
+                                )
+                            })
+                            .collect::<Vec<Cell>>();
+
+                        let secondary = SecondaryIndexCell::new_from(tx_index_cell, log_no + 1);
+
+                        let collection = CellsUpdate::<PrimaryIndex> {
+                            previous_row_key: RowTreeKey::default(),
+                            new_row_key: RowTreeKey::from(&secondary),
+                            updated_cells: [
+                                vec![log_no_cell, gas_used_cell],
+                                topics_cells,
+                                data_cells,
+                            ]
+                            .concat(),
+                            primary: block,
+                        };
+
+                        TableRowUpdate::<PrimaryIndex>::Insertion(collection, secondary)
+                    })
+                    .collect::<Vec<TableRowUpdate<PrimaryIndex>>>()
+            })
+            .collect::<Vec<TableRowUpdate<PrimaryIndex>>>()
+    }
 }
 
 impl<const NO_TOPICS: usize, const MAX_DATA: usize> ReceiptExtractionArgs
@@ -1214,6 +1308,7 @@ where
         ctx: &'a mut TestContext,
         contract: &'a Contract,
     ) -> BoxFuture<'a, Vec<TableRowUpdate<BlockPrimaryIndex>>> {
+        let event = self.get_event();
         async move {
             let contract_update =
                 ReceiptUpdate::new((R::NO_TOPICS as u8, R::MAX_DATA as u8), 5, 15);
@@ -1228,7 +1323,21 @@ where
                 .apply_update(ctx, &contract_update)
                 .await
                 .unwrap();
-            vec![]
+
+            let block_number = ctx.block_number().await;
+            let new_block_number = block_number as BlockPrimaryIndex;
+
+            let query = ReceiptQuery::<{ R::NO_TOPICS }, { R::MAX_DATA }> {
+                contract: contract.address(),
+                event,
+            };
+
+            let proof_infos = query
+                .query_receipt_proofs(provider.root(), block_number.into())
+                .await
+                .unwrap();
+
+            R::to_table_rows(&proof_infos, &event, new_block_number)
         }
         .boxed()
     }

--- a/mp2-v1/tests/common/rowtree.rs
+++ b/mp2-v1/tests/common/rowtree.rs
@@ -42,7 +42,7 @@ impl SecondaryIndexCell {
     }
 
     pub fn cell(&self) -> Cell {
-        self.0.clone()
+        self.0
     }
     pub fn rest(&self) -> RowTreeKeyNonce {
         self.1.clone()

--- a/ryhope/src/storage/updatetree.rs
+++ b/ryhope/src/storage/updatetree.rs
@@ -36,6 +36,7 @@ pub struct UpdateTreeNode<K: Clone + Hash + Eq> {
     /// Whether this node is a leaf of an update path
     is_path_end: bool,
 }
+
 impl<K: Debug + Clone + Hash + Eq> UpdateTreeNode<K> {
     fn is_leaf(&self) -> bool {
         self.children.is_empty()


### PR DESCRIPTION
This PR adds the functionality to produce `TableRowUpdates` based on a series of receipts recovered from a block. It resolves CRY-25.