### PR TITLE
Full Receipt Integration Test (Part 3)

### DIFF
--- a/mp2-common/src/eth.rs
+++ b/mp2-common/src/eth.rs
@@ -72,6 +72,44 @@ pub fn extract_child_hashes(rlp_data: &[u8]) -> Vec<Vec<u8>> {
     hashes
 }
 
+/// Enum used to distinguish between different types of node in an MPT.
+#[derive(Clone, Debug, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum NodeType {
+    Branch,
+    Extension,
+    Leaf,
+}
+
+/// Function that returns the [`NodeType`] of an RLP encoded MPT node
+pub fn node_type(rlp_data: &[u8]) -> Result<NodeType> {
+    let rlp = Rlp::new(rlp_data);
+
+    let item_count = rlp.item_count()?;
+
+    if item_count == 17 {
+        Ok(NodeType::Branch)
+    } else if item_count == 2 {
+        // The first item is the encoded path, if it begins with a 2 or 3 it is a leaf, else it is an extension node
+        let first_item = rlp.at(0)?;
+
+        // We want the first byte
+        let first_byte = first_item.as_raw()[0];
+
+        // The we divide by 16 to get the first nibble
+        match first_byte / 16 {
+            0 | 1 => Ok(NodeType::Extension),
+            2 | 3 => Ok(NodeType::Leaf),
+            _ => Err(anyhow!(
+                "Expected compact encoding beginning with 0,1,2 or 3"
+            )),
+        }
+    } else {
+        Err(anyhow!(
+            "RLP encoded Node item count was {item_count}, expected either 17 or 2"
+        ))
+    }
+}
+
 pub fn left_pad32(slice: &[u8]) -> [u8; 32] {
     left_pad::<32>(slice)
 }

--- a/mp2-v1/src/api.rs
+++ b/mp2-v1/src/api.rs
@@ -75,6 +75,10 @@ impl PublicParameters {
     pub fn get_params_info(&self) -> Result<Vec<u8>> {
         self.tree_creation.get_params_info()
     }
+
+    pub fn get_value_extraction_params(&self) -> &values_extraction::PublicParameters {
+        &self.values_extraction
+    }
 }
 
 /// Instantiate the circuits employed for the pre-processing stage of LPN,

--- a/mp2-v1/src/values_extraction/leaf_receipt.rs
+++ b/mp2-v1/src/values_extraction/leaf_receipt.rs
@@ -22,6 +22,7 @@ use mp2_common::{
     public_inputs::PublicInputCommon,
     rlp::MAX_KEY_NIBBLE_LEN,
     types::{CBuilder, GFp},
+    u256::UInt256Target,
     utils::{less_than, less_than_or_equal_to_unsafe, Endianness, PackerTarget, ToTargets},
     D, F,
 };
@@ -205,9 +206,20 @@ impl EventWires {
             b.mul(tmp, scalar)
         });
 
-        // Map the gas used to a curve point for the value digest, gas used is the first column so use one as its column id.
-        let gas_digest = b.map_to_curve_point(&[gas_used_column_id, gas_used]);
-        let tx_index_digest = b.map_to_curve_point(&[tx_index_column_id, tx_index]);
+        // Convert gas into a UInt256Target as we know it fits into a u32 (We summed 3 bytes, there are 4 bytes in a u32)
+        let gas_used_u256 = UInt256Target::new_from_target_unsafe(b, gas_used);
+
+        let gas_values = iter::once(gas_used_column_id)
+            .chain(gas_used_u256.to_targets())
+            .collect::<Vec<Target>>();
+        let gas_digest = b.map_to_curve_point(&gas_values);
+
+        // For transaction index digest we know the transaction index will always fit in a u32
+        let tx_index_uint256 = UInt256Target::new_from_target_unsafe(b, tx_index);
+        let tx_index_values = iter::once(tx_index_column_id)
+            .chain(tx_index_uint256.to_targets())
+            .collect::<Vec<Target>>();
+        let tx_index_digest = b.map_to_curve_point(&tx_index_values);
 
         let initial_row_digest = b.add_curve_point(&[gas_digest, tx_index_digest]);
         // We also keep track of the number of real logs we process as each log forms a row in our table
@@ -263,7 +275,12 @@ impl EventWires {
             // We also keep track of which log this is in the receipt to avoid having identical rows in the table in the case
             // that the event we are tracking can be emitted multiple times in the same transaction but has no topics or data.
             let log_number = b.constant(F::from_canonical_usize(index + 1));
-            let log_no_digest = b.map_to_curve_point(&[log_number_column_id, log_number]);
+            // This number will always fit into a u32 so we can directly call `UInt256Target::from_target_unsafe`
+            let log_number_uint256 = UInt256Target::new_from_target_unsafe(b, log_number);
+            let log_no_values = iter::once(log_number_column_id)
+                .chain(log_number_uint256.to_targets())
+                .collect::<Vec<Target>>();
+            let log_no_digest = b.map_to_curve_point(&log_no_values);
             points.push(log_no_digest);
 
             let increment = b.select(dummy, zero, one);

--- a/mp2-v1/src/values_extraction/planner.rs
+++ b/mp2-v1/src/values_extraction/planner.rs
@@ -96,6 +96,10 @@ impl<const NO_TOPICS: usize, const MAX_DATA: usize> Extractable
         let key_paths = proofs
             .iter()
             .map(|input| {
+                let digest =
+                    crate::values_extraction::compute_receipt_leaf_value_digest(input, self)
+                        .to_weierstrass();
+                println!("extraction proof values digest: {:?}", digest);
                 let tx_index = input.tx_index;
                 input
                     .mpt_proof

--- a/mp2-v1/src/values_extraction/planner.rs
+++ b/mp2-v1/src/values_extraction/planner.rs
@@ -96,12 +96,7 @@ impl<const NO_TOPICS: usize, const MAX_DATA: usize> Extractable
         let key_paths = proofs
             .iter()
             .map(|input| {
-                let digest =
-                    crate::values_extraction::compute_receipt_leaf_value_digest(input, self)
-                        .to_weierstrass();
-                println!("extraction proof values digest: {:?}", digest);
                 let tx_index = input.tx_index;
-                println!("tx index: {}", tx_index);
                 input
                     .mpt_proof
                     .iter()

--- a/mp2-v1/src/values_extraction/planner.rs
+++ b/mp2-v1/src/values_extraction/planner.rs
@@ -101,6 +101,7 @@ impl<const NO_TOPICS: usize, const MAX_DATA: usize> Extractable
                         .to_weierstrass();
                 println!("extraction proof values digest: {:?}", digest);
                 let tx_index = input.tx_index;
+                println!("tx index: {}", tx_index);
                 input
                     .mpt_proof
                     .iter()

--- a/mp2-v1/src/values_extraction/planner.rs
+++ b/mp2-v1/src/values_extraction/planner.rs
@@ -6,10 +6,13 @@ use alloy::{
     transports::Transport,
 };
 use anyhow::Result;
-use mp2_common::eth::{EventLogInfo, ReceiptQuery};
-use ryhope::storage::updatetree::UpdateTree;
+use mp2_common::eth::{node_type, EventLogInfo, NodeType, ReceiptQuery};
+use ryhope::storage::updatetree::{Next, UpdateTree};
 use std::future::Future;
 
+use std::collections::HashMap;
+
+use super::{generate_proof, CircuitInput, PublicParameters};
 /// Trait that is implemented for all data that we can provably extract.
 pub trait Extractable {
     fn create_update_tree<T: Transport + Clone>(
@@ -18,6 +21,33 @@ pub trait Extractable {
         epoch: u64,
         provider: &RootProvider<T, Ethereum>,
     ) -> impl Future<Output = Result<UpdateTree<B256>>>;
+
+    fn prove_value_extraction<T: Transport + Clone>(
+        &self,
+        contract: Address,
+        epoch: u64,
+        pp: &PublicParameters,
+        provider: &RootProvider<T, Ethereum>,
+    ) -> impl Future<Output = Result<Vec<u8>>>;
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+struct ProofData {
+    node: Vec<u8>,
+    node_type: NodeType,
+    tx_index: Option<u64>,
+    proof: Option<Vec<u8>>,
+}
+
+impl ProofData {
+    pub fn new(node: Vec<u8>, node_type: NodeType, tx_index: Option<u64>) -> ProofData {
+        ProofData {
+            node,
+            node_type,
+            tx_index,
+            proof: None,
+        }
+    }
 }
 
 impl<const NO_TOPICS: usize, const MAX_DATA: usize> Extractable
@@ -45,6 +75,158 @@ impl<const NO_TOPICS: usize, const MAX_DATA: usize> Extractable
         // Now we make the UpdateTree
         Ok(UpdateTree::<B256>::from_paths(key_paths, epoch as i64))
     }
+
+    async fn prove_value_extraction<T: Transport + Clone>(
+        &self,
+        contract: Address,
+        epoch: u64,
+        pp: &PublicParameters,
+        provider: &RootProvider<T, Ethereum>,
+    ) -> Result<Vec<u8>> {
+        let query = ReceiptQuery::<NO_TOPICS, MAX_DATA> {
+            contract,
+            event: *self,
+        };
+
+        let proofs = query.query_receipt_proofs(provider, epoch.into()).await?;
+
+        let mut data_store = HashMap::<B256, ProofData>::new();
+
+        // Convert the paths into their keys using keccak
+        let key_paths = proofs
+            .iter()
+            .map(|input| {
+                let tx_index = input.tx_index;
+                input
+                    .mpt_proof
+                    .iter()
+                    .map(|node| {
+                        let node_key = keccak256(node);
+                        let node_type = node_type(node)?;
+                        let tx = if let NodeType::Leaf = node_type {
+                            Some(tx_index)
+                        } else {
+                            None
+                        };
+                        data_store.insert(node_key, ProofData::new(node.clone(), node_type, tx));
+
+                        Ok(node_key)
+                    })
+                    .collect::<Result<Vec<B256>>>()
+            })
+            .collect::<Result<Vec<Vec<B256>>>>()?;
+
+        let update_tree = UpdateTree::<B256>::from_paths(key_paths, epoch as i64);
+
+        let mut update_plan = update_tree.clone().into_workplan();
+
+        while let Some(Next::Ready(work_plan_item)) = update_plan.next() {
+            let node_type = data_store
+                .get(work_plan_item.k())
+                .ok_or(anyhow::anyhow!(
+                    "No ProofData found for key: {:?}",
+                    work_plan_item.k()
+                ))?
+                .node_type;
+
+            let update_tree_node =
+                update_tree
+                    .get_node(work_plan_item.k())
+                    .ok_or(anyhow::anyhow!(
+                        "No UpdateTreeNode found for key: {:?}",
+                        work_plan_item.k()
+                    ))?;
+
+            match node_type {
+                NodeType::Leaf => {
+                    let proof_data =
+                        data_store
+                            .get_mut(work_plan_item.k())
+                            .ok_or(anyhow::anyhow!(
+                                "No ProofData found for key: {:?}",
+                                work_plan_item.k()
+                            ))?;
+                    let input = CircuitInput::new_receipt_leaf(
+                        &proof_data.node,
+                        proof_data.tx_index.unwrap(),
+                        self,
+                    );
+                    let proof = generate_proof(pp, input)?;
+                    proof_data.proof = Some(proof);
+                    update_plan.done(&work_plan_item)?;
+                }
+                NodeType::Extension => {
+                    let child_key = update_tree.get_child_keys(update_tree_node);
+                    if child_key.len() != 1 {
+                        return Err(anyhow::anyhow!("When proving extension node had {} many child keys when we should only have 1", child_key.len()));
+                    }
+                    let child_proof = data_store
+                        .get(&child_key[0])
+                        .ok_or(anyhow::anyhow!(
+                            "Extension node child had no proof data for key: {:?}",
+                            child_key[0]
+                        ))?
+                        .clone();
+                    let proof_data =
+                        data_store
+                            .get_mut(work_plan_item.k())
+                            .ok_or(anyhow::anyhow!(
+                                "No ProofData found for key: {:?}",
+                                work_plan_item.k()
+                            ))?;
+                    let input = CircuitInput::new_extension(
+                        proof_data.node.clone(),
+                        child_proof.proof.ok_or(anyhow::anyhow!(
+                            "Extension node child proof was a None value"
+                        ))?,
+                    );
+                    let proof = generate_proof(pp, input)?;
+                    proof_data.proof = Some(proof);
+                    update_plan.done(&work_plan_item)?;
+                }
+                NodeType::Branch => {
+                    let child_keys = update_tree.get_child_keys(update_tree_node);
+                    let child_proofs = child_keys
+                        .iter()
+                        .map(|key| {
+                            data_store
+                                .get(key)
+                                .ok_or(anyhow::anyhow!(
+                                    "Branch child data could not be found for key: {:?}",
+                                    key
+                                ))?
+                                .clone()
+                                .proof
+                                .ok_or(anyhow::anyhow!("No proof found in brnach node child"))
+                        })
+                        .collect::<Result<Vec<Vec<u8>>>>()?;
+                    let proof_data =
+                        data_store
+                            .get_mut(work_plan_item.k())
+                            .ok_or(anyhow::anyhow!(
+                                "No ProofData found for key: {:?}",
+                                work_plan_item.k()
+                            ))?;
+                    let input = CircuitInput::new_mapping_variable_branch(
+                        proof_data.node.clone(),
+                        child_proofs,
+                    );
+                    let proof = generate_proof(pp, input)?;
+                    proof_data.proof = Some(proof);
+                    update_plan.done(&work_plan_item)?;
+                }
+            }
+        }
+
+        let final_data = data_store
+            .get(update_tree.root())
+            .ok_or(anyhow::anyhow!("No data for root of update tree found"))?
+            .clone();
+
+        final_data
+            .proof
+            .ok_or(anyhow::anyhow!("No proof stored for final data"))
+    }
 }
 
 #[cfg(test)]
@@ -52,9 +234,20 @@ pub mod tests {
 
     use alloy::{eips::BlockNumberOrTag, primitives::Address, providers::ProviderBuilder, sol};
     use anyhow::anyhow;
-    use mp2_common::eth::BlockUtil;
+    use eth_trie::Trie;
+    use mp2_common::{
+        digest::Digest,
+        eth::BlockUtil,
+        proof::ProofWithVK,
+        utils::{Endianness, Packer},
+    };
     use mp2_test::eth::get_mainnet_url;
     use std::str::FromStr;
+
+    use crate::values_extraction::{
+        api::build_circuits_params, compute_receipt_leaf_metadata_digest,
+        compute_receipt_leaf_value_digest, PublicInputs,
+    };
 
     use super::*;
 
@@ -77,6 +270,67 @@ pub mod tests {
         let block_util = build_test_data().await;
 
         assert_eq!(*update_tree.root(), block_util.block.header.receipts_root);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_receipt_proving() -> Result<()> {
+        // First get the info we will feed in to our function
+        let event_info = test_receipt_trie_helper().await?;
+
+        let contract = Address::from_str("0xbd3531da5cf5857e7cfaa92426877b022e612cf8")?;
+        let epoch: u64 = 21362445;
+
+        let url = get_mainnet_url();
+        // get some tx and receipt
+        let provider = ProviderBuilder::new().on_http(url.parse().unwrap());
+
+        let pp = build_circuits_params();
+        let final_proof_bytes = event_info
+            .prove_value_extraction(contract, epoch, &pp, &provider)
+            .await?;
+
+        let final_proof = ProofWithVK::deserialize(&final_proof_bytes)?;
+        let query = ReceiptQuery::<2, 1> {
+            contract,
+            event: event_info,
+        };
+
+        let metadata_digest = compute_receipt_leaf_metadata_digest(&event_info);
+
+        let value_digest = query
+            .query_receipt_proofs(&provider, epoch.into())
+            .await?
+            .iter()
+            .fold(Digest::NEUTRAL, |acc, info| {
+                acc + compute_receipt_leaf_value_digest(info, &event_info)
+            });
+
+        let pi = PublicInputs::new(&final_proof.proof.public_inputs);
+
+        let mut block_util = build_test_data().await;
+        // Check the output hash
+        {
+            assert_eq!(
+                pi.root_hash(),
+                block_util
+                    .receipts_trie
+                    .root_hash()?
+                    .0
+                    .to_vec()
+                    .pack(Endianness::Little)
+            );
+        }
+
+        // Check value digest
+        {
+            assert_eq!(pi.values_digest(), value_digest.to_weierstrass());
+        }
+
+        // Check metadata digest
+        {
+            assert_eq!(pi.metadata_digest(), metadata_digest.to_weierstrass());
+        }
         Ok(())
     }
 

--- a/mp2-v1/tests/common/cases/indexing.rs
+++ b/mp2-v1/tests/common/cases/indexing.rs
@@ -738,7 +738,7 @@ impl<T: TableSource> TableIndexing<T> {
             }
         };
 
-        let table_id = &self.table.public_name.clone();
+        let table_id = &self.table.public_name;
         // we construct the proof key for both mappings and single variable in the same way since
         // it is derived from the table id which should be different for any tables we create.
         let value_key = ProofKey::ValueExtraction((table_id.clone(), bn as BlockPrimaryIndex));

--- a/mp2-v1/tests/common/cases/indexing.rs
+++ b/mp2-v1/tests/common/cases/indexing.rs
@@ -508,7 +508,24 @@ impl<T: TableSource> TableIndexing<T> {
                 .source
                 .random_contract_update(ctx, &self.contract, ut)
                 .await;
+            // If we are dealing with receipts we need to remove everything already in the row tree
             let bn = ctx.block_number().await as BlockPrimaryIndex;
+
+            let table_row_updates = if let ChangeType::Receipt(..) = ut {
+                let current_row_epoch = self.table.row.current_epoch();
+                let current_row_keys = self
+                    .table
+                    .row
+                    .keys_at(current_row_epoch)
+                    .await
+                    .into_iter()
+                    .map(TableRowUpdate::<BlockPrimaryIndex>::Deletion)
+                    .collect::<Vec<_>>();
+                [current_row_keys, table_row_updates].concat()
+            } else {
+                table_row_updates
+            };
+
             log::info!("Applying follow up updates to contract done - now at block {bn}",);
             // we first run the initial preprocessing and db creation.
             // NOTE: we don't show copy on write here - the fact of only reproving what has been

--- a/mp2-v1/tests/common/cases/indexing.rs
+++ b/mp2-v1/tests/common/cases/indexing.rs
@@ -1031,15 +1031,16 @@ where
         self.apply_update(ctx, contract).await
     }
 }
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Copy)]
 pub enum ChangeType {
     Deletion,
     Insertion,
     Update(UpdateType),
     Silent,
+    Receipt(usize, usize),
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Copy)]
 pub enum UpdateType {
     SecondaryIndex,
     Rest,

--- a/mp2-v1/tests/common/cases/table_source.rs
+++ b/mp2-v1/tests/common/cases/table_source.rs
@@ -1141,7 +1141,7 @@ pub trait ReceiptExtractionArgs:
 
     fn get_index(&self) -> u64;
 
-    fn to_table_rows<PrimaryIndex: Copy>(
+    fn to_table_rows<PrimaryIndex: Clone>(
         proof_infos: &[ReceiptProofInfo],
         event: &EventLogInfo<{ Self::NO_TOPICS }, { Self::MAX_DATA }>,
         block: PrimaryIndex,
@@ -1221,7 +1221,7 @@ pub trait ReceiptExtractionArgs:
                                 data_cells,
                             ]
                             .concat(),
-                            primary: block,
+                            primary: block.clone(),
                         };
 
                         TableRowUpdate::<PrimaryIndex>::Insertion(collection, secondary)

--- a/mp2-v1/tests/common/cases/table_source.rs
+++ b/mp2-v1/tests/common/cases/table_source.rs
@@ -34,7 +34,7 @@ use mp2_v1::{
     values_extraction::{
         compute_all_receipt_coulmn_ids, compute_receipt_leaf_metadata_digest,
         identifier_for_mapping_key_column, identifier_for_mapping_value_column,
-        identifier_single_var_column,
+        identifier_single_var_column, planner::Extractable,
     },
 };
 use plonky2::field::types::PrimeField64;
@@ -444,6 +444,9 @@ impl SingleValuesExtractionArgs {
                     current_values.s2 = next_value();
                 }
             },
+            ChangeType::Receipt(..) => {
+                panic!("Can't process a Receipt update type for a Simple variable")
+            }
         };
 
         let contract_update = UpdateSimpleStorage::Single(current_values);
@@ -718,6 +721,7 @@ impl MappingValuesExtractionArgs {
                     }
                 }
             }
+            ChangeType::Receipt(..) => panic!("Can't process Receipt update type for a Mapping"),
         };
         // small iteration to always have a good updated list of mapping keys
         for update in mapping_updates.iter() {
@@ -1344,20 +1348,76 @@ where
 
     async fn generate_extraction_proof_inputs(
         &self,
-        _ctx: &mut TestContext,
-        _contract: &Contract,
-        _value_key: ProofKey,
+        ctx: &mut TestContext,
+        contract: &Contract,
+        value_key: ProofKey,
     ) -> Result<(ExtractionProofInput, HashOutput)> {
-        todo!("Implement as part of CRY-25")
+        let event = self.get_event();
+
+        let ProofKey::ValueExtraction((_, bn)) = value_key else {
+            bail!("key wrong");
+        };
+
+        let provider = ProviderBuilder::new()
+            .with_recommended_fillers()
+            .wallet(ctx.wallet())
+            .on_http(ctx.rpc_url.parse().unwrap());
+
+        let value_proof = event
+            .prove_value_extraction(
+                contract.address(),
+                bn as u64,
+                ctx.params().get_value_extraction_params(),
+                provider.root(),
+            )
+            .await?;
+        Ok((
+            ExtractionProofInput::Receipt(value_proof),
+            self.metadata_hash(contract.address(), contract.chain_id()),
+        ))
     }
 
     fn random_contract_update<'a>(
         &'a mut self,
-        _ctx: &'a mut TestContext,
-        _contract: &'a Contract,
-        _c: ChangeType,
+        ctx: &'a mut TestContext,
+        contract: &'a Contract,
+        c: ChangeType,
     ) -> BoxFuture<'a, Vec<TableRowUpdate<BlockPrimaryIndex>>> {
-        todo!("Implement as part of CRY-25")
+        let event = self.get_event();
+        async move {
+            let ChangeType::Receipt(relevant, others) = c else {
+                panic!("Need ChangeType::Receipt, got: {:?}", c);
+            };
+            let contract_update =
+                ReceiptUpdate::new((R::NO_TOPICS as u8, R::MAX_DATA as u8), relevant, others);
+
+            let provider = ProviderBuilder::new()
+                .with_recommended_fillers()
+                .wallet(ctx.wallet())
+                .on_http(ctx.rpc_url.parse().unwrap());
+
+            let event_emitter = EventContract::new(contract.address(), provider.root());
+            event_emitter
+                .apply_update(ctx, &contract_update)
+                .await
+                .unwrap();
+
+            let block_number = ctx.block_number().await;
+            let new_block_number = block_number as BlockPrimaryIndex;
+
+            let query = ReceiptQuery::<{ R::NO_TOPICS }, { R::MAX_DATA }> {
+                contract: contract.address(),
+                event,
+            };
+
+            let proof_infos = query
+                .query_receipt_proofs(provider.root(), block_number.into())
+                .await
+                .unwrap();
+
+            R::to_table_rows(&proof_infos, &event, new_block_number)
+        }
+        .boxed()
     }
 
     fn metadata_hash(&self, _contract_address: Address, _chain_id: u64) -> MetadataHash {

--- a/mp2-v1/tests/common/cases/table_source.rs
+++ b/mp2-v1/tests/common/cases/table_source.rs
@@ -1193,7 +1193,7 @@ pub trait ReceiptExtractionArgs:
                             .skip(1)
                             .map(|(j, topic)| {
                                 Cell::new(
-                                    *column_ids.get(&format!("topic_{}", j)).unwrap(),
+                                    *column_ids.get(&format!("topic_{}", j + 1)).unwrap(),
                                     topic.into(),
                                 )
                             })

--- a/mp2-v1/tests/common/final_extraction.rs
+++ b/mp2-v1/tests/common/final_extraction.rs
@@ -22,10 +22,13 @@ pub struct MergeExtractionProof {
     pub mapping: ExtractionTableProof,
 }
 
+type ReceiptExtractionProof = Vec<u8>;
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum ExtractionProofInput {
     Single(ExtractionTableProof),
     Merge(MergeExtractionProof),
+    Receipt(ReceiptExtractionProof),
 }
 
 impl TestContext {
@@ -57,6 +60,9 @@ impl TestContext {
                 inputs.single.value_proof,
                 inputs.mapping.value_proof,
             ),
+            ExtractionProofInput::Receipt(input) => {
+                CircuitInput::new_receipt_input(block_proof, input)
+            }
         }?;
         let params = self.params();
         let proof = self

--- a/mp2-v1/tests/common/table.rs
+++ b/mp2-v1/tests/common/table.rs
@@ -430,6 +430,9 @@ impl Table {
             .map(|plan| RowUpdateResult { updates: plan });
         {
             // debugging
+            if out.is_err() {
+                println!("Out was an error: {:?}", out);
+            }
             println!("\n+++++++++++++++++++++++++++++++++\n");
             let root = self.row.root_data().await.unwrap();
             let new_epoch = self.row.current_epoch();
@@ -491,7 +494,7 @@ pub enum TreeRowUpdate {
     Deletion(RowTreeKey),
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct RowUpdateResult {
     // There is only a single row key for a table that we update continuously
     // so no need to track all the rows that have been updated in the result

--- a/mp2-v1/tests/integrated_tests.rs
+++ b/mp2-v1/tests/integrated_tests.rs
@@ -90,9 +90,15 @@ async fn integrated_indexing() -> Result<()> {
     ctx.build_params(ParamsType::Indexing).unwrap();
 
     info!("Params built");
-    // For now we test that we can start a receipt case only.
-    let (_receipt, _genesis) =
+
+    let (mut receipt, genesis) =
         TableIndexing::<EventLogInfo<0, 0>>::receipt_test_case(0, 0, &mut ctx).await?;
+    let changes = vec![
+        ChangeType::Receipt(1, 10),
+        ChangeType::Receipt(10, 1),
+        ChangeType::Receipt(0, 10),
+    ];
+    receipt.run(&mut ctx, genesis, changes.clone()).await?;
 
     // NOTE: to comment to avoid very long tests...
     let (mut single, genesis) =

--- a/ryhope/src/storage/updatetree.rs
+++ b/ryhope/src/storage/updatetree.rs
@@ -41,9 +41,13 @@ impl<K: Debug + Clone + Hash + Eq> UpdateTreeNode<K> {
     fn is_leaf(&self) -> bool {
         self.children.is_empty()
     }
+
+    pub fn k(&self) -> K {
+        self.k.clone()
+    }
 }
 
-impl<K: Clone + Hash + Eq> UpdateTree<K> {
+impl<K: Clone + Hash + Eq + Debug> UpdateTree<K> {
     pub fn root(&self) -> &K {
         &self.nodes[0].k
     }
@@ -54,6 +58,17 @@ impl<K: Clone + Hash + Eq> UpdateTree<K> {
 
     fn node_mut(&mut self, i: usize) -> &mut UpdateTreeNode<K> {
         &mut self.nodes[i]
+    }
+
+    pub fn get_node(&self, key: &K) -> Option<&UpdateTreeNode<K>> {
+        self.idx.get(key).map(|idx| self.node(*idx))
+    }
+
+    pub fn get_child_keys(&self, node: &UpdateTreeNode<K>) -> Vec<K> {
+        node.children
+            .iter()
+            .map(|idx| self.node(*idx).k())
+            .collect()
     }
 }
 


### PR DESCRIPTION
This PR will resolve CRY-24 upon merge. It adds the functionality to provide a series of `ChangeType::Receipt` in the indexing integration test and then prove both value extraction and the correct construction of the verifiable DB. It also adds some extra code to check if we are in the Receipt case to `Table::run_lagrange_preprocessing()` method. This was added so that it first wipes the row tree before building the new one, as there will be no crossover between blocks. 