### PR TITLE
feat: add primary index bracketing check

### DIFF
--- a/mp2-v1/tests/common/cases/query/aggregated_queries.rs
+++ b/mp2-v1/tests/common/cases/query/aggregated_queries.rs
@@ -58,8 +58,8 @@ use tokio_postgres::Row as PsqlRow;
 use verifiable_db::{
     ivc::PublicInputs as IndexingPIS,
     query::{
-        computational_hash_ids::{ColumnIDs, Identifiers},
-        universal_circuit::universal_circuit_inputs::{ColumnCell, PlaceholderId, Placeholders},
+        computational_hash_ids::{ColumnIDs, Identifiers, PlaceholderIdentifier},
+        universal_circuit::universal_circuit_inputs::{ColumnCell, Placeholders},
     },
     revelation::PublicInputs,
 };
@@ -472,8 +472,8 @@ pub(crate) async fn cook_query_secondary_index_nonexisting_placeholder(
     let random_value = U256::from(1234567890);
     let placeholders = Placeholders::from((
         vec![
-            (PlaceholderId::Generic(1), random_value),
-            (PlaceholderId::Generic(2), filtering_value),
+            (PlaceholderIdentifier::Generic(1), random_value),
+            (PlaceholderIdentifier::Generic(2), filtering_value),
         ],
         U256::from(min_block),
         U256::from(max_block),
@@ -518,8 +518,8 @@ pub(crate) async fn cook_query_secondary_index_placeholder(
 
     let placeholders = Placeholders::from((
         vec![
-            (PlaceholderId::Generic(1), longest_key.value),
-            (PlaceholderId::Generic(2), filtering_value),
+            (PlaceholderIdentifier::Generic(1), longest_key.value),
+            (PlaceholderIdentifier::Generic(2), filtering_value),
         ],
         U256::from(min_block),
         U256::from(max_block),

--- a/mp2-v1/tests/common/cases/query/simple_select_queries.rs
+++ b/mp2-v1/tests/common/cases/query/simple_select_queries.rs
@@ -26,10 +26,8 @@ use std::{fmt::Debug, hash::Hash};
 use tokio_postgres::Row as PgSqlRow;
 use verifiable_db::{
     query::{
-        computational_hash_ids::ColumnIDs,
-        universal_circuit::universal_circuit_inputs::{
-            ColumnCell, PlaceholderId, Placeholders, RowCells,
-        },
+        computational_hash_ids::{ColumnIDs, PlaceholderIdentifier},
+        universal_circuit::universal_circuit_inputs::{ColumnCell, Placeholders, RowCells},
         utils::{ChildPosition, NodeInfo},
     },
     revelation::{api::MatchingRow, RowPath},
@@ -328,7 +326,7 @@ pub(crate) async fn cook_query_with_max_num_matching_rows(
     let added_placeholder = U256::from(42);
 
     let placeholders = Placeholders::from((
-        vec![(PlaceholderId::Generic(1), added_placeholder)],
+        vec![(PlaceholderIdentifier::Generic(1), added_placeholder)],
         U256::from(min_block),
         U256::from(max_block),
     ));
@@ -371,7 +369,7 @@ pub(crate) async fn cook_query_with_matching_rows(
     let added_placeholder = U256::from(42);
 
     let placeholders = Placeholders::from((
-        vec![(PlaceholderId::Generic(1), added_placeholder)],
+        vec![(PlaceholderIdentifier::Generic(1), added_placeholder)],
         U256::from(min_block),
         U256::from(max_block),
     ));
@@ -417,7 +415,7 @@ pub(crate) async fn cook_query_too_big_offset(
     let added_placeholder = U256::from(42);
 
     let placeholders = Placeholders::from((
-        vec![(PlaceholderId::Generic(1), added_placeholder)],
+        vec![(PlaceholderIdentifier::Generic(1), added_placeholder)],
         U256::from(min_block),
         U256::from(max_block),
     ));
@@ -461,8 +459,8 @@ pub(crate) async fn cook_query_no_matching_rows(
 
     let placeholders = Placeholders::from((
         vec![
-            (PlaceholderId::Generic(1), key_value),
-            (PlaceholderId::Generic(2), added_placeholder),
+            (PlaceholderIdentifier::Generic(1), key_value),
+            (PlaceholderIdentifier::Generic(2), added_placeholder),
         ],
         U256::from(min_block),
         U256::from(max_block),
@@ -506,7 +504,7 @@ pub(crate) async fn cook_query_with_distinct(
     let added_placeholder = U256::from(42);
 
     let placeholders = Placeholders::from((
-        vec![(PlaceholderId::Generic(1), added_placeholder)],
+        vec![(PlaceholderIdentifier::Generic(1), added_placeholder)],
         U256::from(min_block),
         U256::from(max_block),
     ));
@@ -550,7 +548,7 @@ pub(crate) async fn cook_query_with_wildcard(
     let added_placeholder = U256::from(42);
 
     let placeholders = Placeholders::from((
-        vec![(PlaceholderId::Generic(1), added_placeholder)],
+        vec![(PlaceholderIdentifier::Generic(1), added_placeholder)],
         U256::from(min_block),
         U256::from(max_block),
     ));

--- a/parsil/src/assembler.rs
+++ b/parsil/src/assembler.rs
@@ -289,11 +289,11 @@ impl<'a, C: ContextProvider> Assembler<'a, C> {
         }
     }
 
-    /// Return whether the given `Symbol` encodes the secondary index column.
-    fn is_symbol_kind(s: &Symbol<Wire>, _kind: ColumnKind) -> bool {
+    /// Return whether the given `Symbol` encodes the given kind of column.
+    fn is_symbol_kind(s: &Symbol<Wire>, target: ColumnKind) -> bool {
         match s {
-            Symbol::Column { kind, .. } => *kind == _kind,
-            Symbol::Alias { to, .. } => Self::is_symbol_kind(to, _kind),
+            Symbol::Column { kind, .. } => *kind == target,
+            Symbol::Alias { to, .. } => Self::is_symbol_kind(to, target),
             _ => false,
         }
     }

--- a/parsil/src/assembler.rs
+++ b/parsil/src/assembler.rs
@@ -358,11 +358,7 @@ impl<'a, C: ContextProvider> Assembler<'a, C> {
     ///   - sid <[=] <placeholder>
     ///   - sid >[=] <placeholder>
     ///   - sid = <placeholder>
-    fn maybe_set_secondary_index_boundary(
-        &mut self,
-        expr: &Expr,
-        bounds: &mut Bounds,
-    ) -> Result<()> {
+    fn maybe_set_secondary_index_bounds(&mut self, expr: &Expr, bounds: &mut Bounds) -> Result<()> {
         fn plus_one(expr: &Expr) -> Expr {
             Expr::BinaryOp {
                 left: Box::new(expr.clone()),
@@ -502,7 +498,7 @@ impl<'a, C: ContextProvider> Assembler<'a, C> {
     /// combinators are traversed, as any other one would not statically
     /// guarantee the predominance of the bound.
     fn find_secondary_index_boundaries(&mut self, expr: &Expr, bounds: &mut Bounds) -> Result<()> {
-        self.maybe_set_secondary_index_boundary(expr, bounds)?;
+        self.maybe_set_secondary_index_bounds(expr, bounds)?;
         match expr {
             Expr::BinaryOp {
                 left,

--- a/parsil/src/assembler.rs
+++ b/parsil/src/assembler.rs
@@ -1092,11 +1092,11 @@ impl<C: ContextProvider> AstVisitor for Assembler<'_, C> {
             self.find_primary_index_boundaries(where_clause, &mut primary_index_bounded)?;
             ensure!(
                 primary_index_bounded.0,
-                "min. bound not found for parimary index"
+                "min. bound not found for primary index"
             );
             ensure!(
                 primary_index_bounded.1,
-                "max. bound not found for parimary index"
+                "max. bound not found for primary index"
             );
 
             let mut secondary_index_bounds = Default::default();

--- a/parsil/src/assembler.rs
+++ b/parsil/src/assembler.rs
@@ -502,7 +502,7 @@ impl<'a, C: ContextProvider> Assembler<'a, C> {
             {
                 match op {
                     // $PI > x
-                    BinaryOperator::Gt | BinaryOperator::GtEq => {
+                    BinaryOperator::GtEq => {
                         let bound = self.expression_to_boundary(right)?;
                         if matches!(
                             bound,
@@ -512,7 +512,7 @@ impl<'a, C: ContextProvider> Assembler<'a, C> {
                         }
                     }
                     // $PI < x
-                    BinaryOperator::Lt | BinaryOperator::LtEq => {
+                    BinaryOperator::LtEq => {
                         let bound = self.expression_to_boundary(right)?;
 
                         if matches!(

--- a/parsil/src/assembler.rs
+++ b/parsil/src/assembler.rs
@@ -417,13 +417,13 @@ impl<'a, C: ContextProvider> Assembler<'a, C> {
                         };
                         let bound = self.expression_to_boundary(right)?;
 
-                        maybe_replace_min(&mut bounds.low, bound);
+                        maybe_replace_min(&mut bounds.high, bound);
                     }
                     // $sid = x
                     BinaryOperator::Eq => {
                         let bound = self.expression_to_boundary(right)?;
-                        maybe_replace_min(&mut bounds.high, bound.clone());
-                        maybe_replace_max(&mut bounds.low, bound);
+                        bounds.low = Some(bound.clone());
+                        bounds.high = Some(bound);
                     }
                     _ => {}
                 }
@@ -449,13 +449,13 @@ impl<'a, C: ContextProvider> Assembler<'a, C> {
                         };
                         let bound = self.expression_to_boundary(left)?;
 
-                        maybe_replace_max(&mut bounds.high, bound);
+                        maybe_replace_max(&mut bounds.low, bound);
                     }
                     // x = $sid
                     BinaryOperator::Eq => {
                         let bound = self.expression_to_boundary(left)?;
-                        maybe_replace_max(&mut bounds.high, bound.clone());
-                        maybe_replace_min(&mut bounds.high, bound);
+                        bounds.low = Some(bound.clone());
+                        bounds.high = Some(bound);
                     }
                     _ => {}
                 }

--- a/parsil/src/executor.rs
+++ b/parsil/src/executor.rs
@@ -12,7 +12,7 @@ use sqlparser::ast::{
 use std::collections::HashMap;
 use verifiable_db::query::{
     computational_hash_ids::PlaceholderIdentifier,
-    universal_circuit::universal_circuit_inputs::{PlaceholderId, Placeholders},
+    universal_circuit::universal_circuit_inputs::Placeholders,
 };
 
 use crate::{
@@ -93,7 +93,7 @@ pub struct TranslatedQuery {
     pub query: SafeQuery,
     /// Where each placeholder from the zkSQL query should be put in the array
     /// of PgSQL placeholder.
-    pub placeholder_mapping: HashMap<PlaceholderId, usize>,
+    pub placeholder_mapping: HashMap<PlaceholderIdentifier, usize>,
     /// A mapping from the named placeholders as defined in the settings to the
     /// string representation of numeric placeholders (e.g. from `$MIN_BLOCK` to
     /// `$4`).
@@ -105,9 +105,13 @@ impl TranslatedQuery {
         settings: &ParsilSettings<C>,
     ) -> Result<Self> {
         let used_placeholders = placeholders::gather_placeholders(settings, query.as_mut())?;
-        let placeholder_mapping = std::iter::once(PlaceholderId::MinQueryOnIdx1)
+        let placeholder_mapping = std::iter::once(PlaceholderIdentifier::MinQueryOnIdx1)
             .chain(std::iter::once(PlaceholderIdentifier::MaxQueryOnIdx1))
-            .chain(used_placeholders.iter().map(|i| PlaceholderId::Generic(*i)))
+            .chain(
+                used_placeholders
+                    .iter()
+                    .map(|i| PlaceholderIdentifier::Generic(*i)),
+            )
             .enumerate()
             .map(|(i, p)| (p, i))
             .collect();

--- a/parsil/src/main.rs
+++ b/parsil/src/main.rs
@@ -7,11 +7,8 @@ use clap::{Parser, Subcommand};
 use log::Level;
 use parsil::queries::{core_keys_for_index_tree, core_keys_for_row_tree};
 use ryhope::{tree::sbbst::NodeIdx, Epoch};
-use sqlparser::ast::Query;
-use symbols::{ContextProvider, FileContextProvider};
+use symbols::FileContextProvider;
 use utils::{parse_and_validate, ParsilSettings, PlaceholderSettings};
-use verifiable_db::query::universal_circuit::universal_circuit_inputs::Placeholders;
-use visitor::AstMutator;
 
 mod assembler;
 mod bracketer;
@@ -30,6 +27,12 @@ mod visitor;
 struct Args {
     #[arg(short = 'v', global = true)]
     verbose: bool,
+
+    #[arg(long, short = 'L', global = true)]
+    limit: Option<u32>,
+
+    #[arg(long, short = 'O', global = true)]
+    offset: Option<u32>,
 
     #[command(subcommand)]
     command: Command,
@@ -67,29 +70,39 @@ enum Command {
     /// Modify the given query to neuter all WHERE clauses not related to
     /// indices.
     Isolate {
-        #[arg()]
+        #[arg(long, short = 'Q')]
         request: String,
+
+        /// The lower bound of the secondary index, if any.
         #[arg(long)]
-        lo_sec: bool,
+        lo_sec: Option<String>,
+
+        /// The higher bound of the secondary index, if any.
         #[arg(long)]
-        hi_sec: bool,
+        hi_sec: Option<String>,
+
         #[arg(long)]
         to_keys: bool,
     },
     Core {
+        #[arg(long, short = 'Q')]
         request: String,
 
-        #[arg(short = 'E', long)]
         /// The epoch at which to run the query
+        #[arg(short = 'E', long)]
         epoch: Epoch,
 
-        #[arg(short = 'm', long)]
         /// Primary index lower bound
+        #[arg(short = 'm', long)]
         min_block: i64,
 
-        #[arg(short = 'M', long)]
         /// Primary index upper bound
+        #[arg(short = 'M', long)]
         max_block: i64,
+
+        /// The type of tree
+        #[arg(long="tree", value_parser = ["row", "index"])]
+        tree_type: String,
     },
 }
 
@@ -99,23 +112,31 @@ enum QueryKind {
     Keys,
 }
 
-fn prepare<C: ContextProvider>(settings: &ParsilSettings<C>, query: &str) -> Result<Query> {
-    let mut query = parser::parse(settings, query)?;
-    expand::expand(&mut query);
-    Ok(query)
-}
+const MAX_NUM_COLUMNS: usize = 10;
+const MAX_NUM_PREDICATE_OPS: usize = 20;
+const MAX_NUM_RESULT_OPS: usize = 20;
+const MAX_NUM_ITEMS_PER_OUTPUT: usize = 10;
+const MAX_NUM_OUTPUTS: usize = 5;
 
 fn main() -> Result<()> {
     let args = Args::parse();
     stderrlog::new().verbosity(Level::Debug).init().unwrap();
     let settings = ParsilSettings {
-        context: FileContextProvider::from_file("tests/context.json")?,
+        context: FileContextProvider::<
+            MAX_NUM_COLUMNS,
+            MAX_NUM_PREDICATE_OPS,
+            MAX_NUM_RESULT_OPS,
+            MAX_NUM_ITEMS_PER_OUTPUT,
+            MAX_NUM_OUTPUTS,
+        >::from_file("tests/context.json")?,
         placeholders: PlaceholderSettings::with_freestanding(3),
+        limit: args.limit,
+        offset: args.offset,
     };
 
     match args.command {
         Command::Debug { request } => {
-            let mut query = parse_and_validate(&request, &settings)?;
+            let query = parse_and_validate(&request, &settings)?;
             println!("Query string:\n{}", &request);
             if args.verbose {
                 println!("{:#?}", query);
@@ -123,7 +144,7 @@ fn main() -> Result<()> {
             println!("Final query:\n{}", query);
         }
         Command::Circuit { request } => {
-            let mut query = parse_and_validate(&request, &settings)?;
+            let query = parse_and_validate(&request, &settings)?;
             assembler::validate(&query, &settings)?;
             let circuit = assemble_static(&query, &settings)?;
             println!("Statically assembled circuit PIs:\n{circuit:#?}");
@@ -132,11 +153,11 @@ fn main() -> Result<()> {
             let mut query = parse_and_validate(&request, &settings)?;
             match kind {
                 QueryKind::Execute => {
-                    let mut translated = executor::generate_query_execution(&mut query, &settings)?;
+                    let translated = executor::generate_query_execution(&mut query, &settings)?;
                     println!("{}", translated.query.to_display());
                 }
                 QueryKind::Keys => {
-                    let mut translated = executor::generate_query_keys(&mut query, &settings)?;
+                    let translated = executor::generate_query_keys(&mut query, &settings)?;
                     println!("{}", translated.query.to_display());
                 }
             }
@@ -148,9 +169,14 @@ fn main() -> Result<()> {
             to_keys,
         } => {
             let mut query = parse_and_validate(&request, &settings)?;
-            let mut q = isolator::isolate_with(&mut query, &settings, lo_sec, hi_sec)?;
+            let mut q = isolator::isolate_with(
+                &mut query,
+                &settings,
+                lo_sec.map(|s| U256::from_str(&s).unwrap()),
+                hi_sec.map(|s| U256::from_str(&s).unwrap()),
+            )?;
             if to_keys {
-                let mut q = executor::generate_query_keys(&mut q, &settings)?;
+                let q = executor::generate_query_keys(&mut q, &settings)?;
                 println!("Query: {}", q.query.to_display());
             } else {
                 println!("{}", q);
@@ -178,16 +204,25 @@ fn main() -> Result<()> {
             epoch,
             min_block,
             max_block,
+            tree_type,
         } => {
-            let mut query = parse_and_validate(&request, &settings)?;
-            let query_index =
-                core_keys_for_index_tree(epoch, (min_block as NodeIdx, max_block as NodeIdx))?;
-            // let query_row = core_keys_for_row_tree(
-            //     qeury,
-            //     &settings,
-            //     (min_block as NodeIdx, max_block as NodeIdx),
-            // )?;
-            println!("INDEX TREE: {query_index}");
+            let q = match tree_type.as_str() {
+                "row" => {
+                    todo!();
+                    // core_keys_for_row_tree(
+                    //     &request,
+                    //     &settings,
+                    //     (min_block as NodeIdx, max_block as NodeIdx),
+                    //     todo!(),
+                    // )?
+                }
+                "index" => {
+                    core_keys_for_index_tree(epoch, (min_block as NodeIdx, max_block as NodeIdx))?
+                }
+                _ => unreachable!(),
+            };
+
+            println!("{q}");
         }
     }
 

--- a/parsil/src/tests.rs
+++ b/parsil/src/tests.rs
@@ -67,7 +67,7 @@ fn prim_index_bounds() -> Result<()> {
         "SELECT pipo FROM table1 WHERE block = pipo + 5 AND block BETWEEN $MIN_BLOCK AND $1"
     )
     .is_err());
-    assert!(check("SELECT pipo FROM table1 WHERE block < MAX_BLOCK").is_err());
+    assert!(check("SELECT pipo FROM table1 WHERE block < $MAX_BLOCK").is_err());
     assert!(check("SELECT pipo FROM table1 WHERE block > $MIN_BLOCK").is_err());
     assert!(
         check("SELECT pipo FROM table1 WHERE block < $MAX_BLOCK AND block > $MIN_BLOCK").is_err()

--- a/parsil/src/tests.rs
+++ b/parsil/src/tests.rs
@@ -70,13 +70,16 @@ fn prim_index_bounds() -> Result<()> {
     assert!(check("SELECT pipo FROM table1 WHERE block < MAX_BLOCK").is_err());
     assert!(check("SELECT pipo FROM table1 WHERE block > $MIN_BLOCK").is_err());
     assert!(
-        check("SELECT pipo FROM table1 WHERE block < $MAX_BLOCK AND block > $MIN_BLOCK").is_ok()
+        check("SELECT pipo FROM table1 WHERE block < $MAX_BLOCK AND block > $MIN_BLOCK").is_err()
     );
     assert!(
-        check("SELECT pipo FROM table1 WHERE block > $MIN_BLOCK AND block < $MAX_BLOCK").is_ok()
+        check("SELECT pipo FROM table1 WHERE block <= $MAX_BLOCK AND block >= $MIN_BLOCK").is_ok()
     );
     assert!(
-        check("SELECT pipo FROM table1 WHERE block > $MAX_BLOCK AND block < $MIN_BLOCK").is_err()
+        check("SELECT pipo FROM table1 WHERE block >= $MIN_BLOCK AND block <= $MAX_BLOCK").is_ok()
+    );
+    assert!(
+        check("SELECT pipo FROM table1 WHERE block >= $MAX_BLOCK AND block <= $MIN_BLOCK").is_err()
     );
     Ok(())
 }

--- a/ryhope/src/storage/pgsql/mod.rs
+++ b/ryhope/src/storage/pgsql/mod.rs
@@ -20,7 +20,7 @@ use std::{
     sync::{Arc, Mutex},
 };
 use storages::{NodeProjection, PayloadProjection};
-use tokio_postgres::{GenericClient, NoTls, Transaction};
+use tokio_postgres::{NoTls, Transaction};
 use tracing::*;
 
 mod storages;

--- a/ryhope/src/storage/pgsql/mod.rs
+++ b/ryhope/src/storage/pgsql/mod.rs
@@ -20,7 +20,7 @@ use std::{
     sync::{Arc, Mutex},
 };
 use storages::{NodeProjection, PayloadProjection};
-use tokio_postgres::{NoTls, Transaction};
+use tokio_postgres::{GenericClient, NoTls, Transaction};
 use tracing::*;
 
 mod storages;

--- a/verifiable-db/src/query/api.rs
+++ b/verifiable-db/src/query/api.rs
@@ -41,13 +41,10 @@ use crate::query::{
 };
 
 use super::{
-    computational_hash_ids::Output,
+    computational_hash_ids::{Output, PlaceholderIdentifier},
     pi_len,
-    universal_circuit::{
-        universal_circuit_inputs::PlaceholderId,
-        universal_query_circuit::{
-            placeholder_hash, UniversalCircuitInput, UniversalQueryCircuitParams,
-        },
+    universal_circuit::universal_query_circuit::{
+        placeholder_hash, UniversalCircuitInput, UniversalQueryCircuitParams,
     },
 };
 
@@ -379,7 +376,7 @@ where
         results: &ResultStructure,
         placeholders: &Placeholders,
         query_bounds: &QueryBounds,
-    ) -> Result<[PlaceholderId; 2 * (MAX_NUM_PREDICATE_OPS + MAX_NUM_RESULT_OPS)]> {
+    ) -> Result<[PlaceholderIdentifier; 2 * (MAX_NUM_PREDICATE_OPS + MAX_NUM_RESULT_OPS)]> {
         UniversalCircuitInput::<
             MAX_NUM_COLUMNS,
             MAX_NUM_PREDICATE_OPS,

--- a/verifiable-db/src/query/circuits/row_chunk_processing.rs
+++ b/verifiable-db/src/query/circuits/row_chunk_processing.rs
@@ -387,7 +387,7 @@ mod tests {
             output_no_aggregation::Circuit as NoAggOutputCircuit,
             output_with_aggregation::Circuit as AggOutputCircuit,
             universal_circuit_inputs::{
-                BasicOperation, ColumnCell, InputOperand, OutputItem, PlaceholderId, Placeholders,
+                BasicOperation, ColumnCell, InputOperand, OutputItem, Placeholders,
                 ResultStructure, RowCells,
             },
             universal_query_circuit::placeholder_hash,
@@ -468,14 +468,14 @@ mod tests {
         let min_query_secondary = U256::from(75);
         let max_query_secondary = U256::from(97686754);
         // define placeholders
-        let first_placeholder_id = PlaceholderId::Generic(0);
+        let first_placeholder_id = PlaceholderIdentifier::Generic(0);
         let second_placeholder_id = PlaceholderIdentifier::Generic(1);
         let mut placeholders = Placeholders::new_empty(min_query_primary, max_query_primary);
         [first_placeholder_id, second_placeholder_id]
             .iter()
             .for_each(|id| placeholders.insert(*id, gen_random_u256(rng)));
         // 3-rd placeholder is max query bound + 1, since the bound is C2 < $3, rather than C2 <= $3
-        let third_placeholder_id = PlaceholderId::Generic(2);
+        let third_placeholder_id = PlaceholderIdentifier::Generic(2);
         placeholders.insert(third_placeholder_id, max_query_secondary + U256::from(1));
         let bounds = QueryBounds::new(
             &placeholders,
@@ -984,14 +984,14 @@ mod tests {
         let min_query_secondary = U256::from(42);
         let max_query_secondary = U256::from(43);
         // define placeholders
-        let first_placeholder_id = PlaceholderId::Generic(0);
+        let first_placeholder_id = PlaceholderIdentifier::Generic(0);
         let second_placeholder_id = PlaceholderIdentifier::Generic(1);
         let mut placeholders = Placeholders::new_empty(min_query_primary, max_query_primary);
         [first_placeholder_id, second_placeholder_id]
             .iter()
             .for_each(|id| placeholders.insert(*id, gen_random_u256(rng)));
         // 3-rd placeholder is the min query bound
-        let third_placeholder_id = PlaceholderId::Generic(2);
+        let third_placeholder_id = PlaceholderIdentifier::Generic(2);
         placeholders.insert(third_placeholder_id, min_query_secondary);
         let query_bounds = QueryBounds::new(
             &placeholders,

--- a/verifiable-db/src/query/universal_circuit/universal_circuit_inputs.rs
+++ b/verifiable-db/src/query/universal_circuit/universal_circuit_inputs.rs
@@ -20,20 +20,18 @@ use super::universal_query_circuit::dummy_placeholder_id;
 /// Data structure representing a placeholder in the query, given by its value and its identifier
 pub struct Placeholder {
     pub(crate) value: U256,
-    pub(crate) id: PlaceholderId,
+    pub(crate) id: PlaceholderIdentifier,
 }
-
-pub type PlaceholderId = PlaceholderIdentifier;
 
 /// Define a set of placeholder ids which can be iterated over
 /// following the ids expected for placeholders as outputs of
 /// the revelation circuit
 #[derive(Clone, Debug)]
-pub(crate) struct PlaceholderIdsSet(BTreeSet<PlaceholderId>);
+pub(crate) struct PlaceholderIdsSet(BTreeSet<PlaceholderIdentifier>);
 
-impl<I: Iterator<Item = PlaceholderId>> From<I> for PlaceholderIdsSet {
+impl<I: Iterator<Item = PlaceholderIdentifier>> From<I> for PlaceholderIdsSet {
     fn from(value: I) -> Self {
-        Self(value.collect::<BTreeSet<PlaceholderId>>())
+        Self(value.collect::<BTreeSet<PlaceholderIdentifier>>())
     }
 }
 
@@ -41,9 +39,9 @@ impl<I: Iterator<Item = PlaceholderId>> From<I> for PlaceholderIdsSet {
 /// the ids according to the order expected in the public inputs of the
 /// revelation circuit
 impl IntoIterator for PlaceholderIdsSet {
-    type Item = PlaceholderId;
+    type Item = PlaceholderIdentifier;
 
-    type IntoIter = btree_set::IntoIter<PlaceholderId>;
+    type IntoIter = btree_set::IntoIter<PlaceholderIdentifier>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.0.into_iter()
@@ -51,16 +49,16 @@ impl IntoIterator for PlaceholderIdsSet {
 }
 
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
-/// Data structure employed to represent a set of placeholders, identified by their `PlaceholderId`
-pub struct Placeholders(pub HashMap<PlaceholderId, U256>);
+/// Data structure employed to represent a set of placeholders, identified by their `PlaceholderIdentifier`
+pub struct Placeholders(pub HashMap<PlaceholderIdentifier, U256>);
 
 impl Placeholders {
     /// Initialize an empty set of placeholders
     pub fn new_empty(min_query_primary: U256, max_query_primary: U256) -> Self {
         Self(
             [
-                (PlaceholderId::MinQueryOnIdx1, min_query_primary),
-                (PlaceholderId::MaxQueryOnIdx1, max_query_primary),
+                (PlaceholderIdentifier::MinQueryOnIdx1, min_query_primary),
+                (PlaceholderIdentifier::MaxQueryOnIdx1, max_query_primary),
             ]
             .into_iter()
             .collect(),
@@ -68,14 +66,14 @@ impl Placeholders {
     }
 
     /// Get the placeholder value corresponding to `id`, if found in the set of placeholders
-    pub fn get(&self, id: &PlaceholderId) -> Result<U256> {
+    pub fn get(&self, id: &PlaceholderIdentifier) -> Result<U256> {
         let value = self.0.get(id);
         ensure!(value.is_some(), "no placeholder found for id {:?}", id);
         Ok(*value.unwrap())
     }
 
     /// Add a new placeholder to `self`
-    pub fn insert(&mut self, id: PlaceholderId, value: U256) {
+    pub fn insert(&mut self, id: PlaceholderIdentifier, value: U256) {
         self.0.insert(id, value);
     }
 
@@ -109,12 +107,12 @@ impl Placeholders {
     }
 }
 
-impl From<(Vec<(PlaceholderId, U256)>, U256, U256)> for Placeholders {
-    fn from(value: (Vec<(PlaceholderId, U256)>, U256, U256)) -> Self {
+impl From<(Vec<(PlaceholderIdentifier, U256)>, U256, U256)> for Placeholders {
+    fn from(value: (Vec<(PlaceholderIdentifier, U256)>, U256, U256)) -> Self {
         Self(
             [
-                (PlaceholderId::MinQueryOnIdx1, value.1),
-                (PlaceholderId::MaxQueryOnIdx1, value.2),
+                (PlaceholderIdentifier::MinQueryOnIdx1, value.1),
+                (PlaceholderIdentifier::MaxQueryOnIdx1, value.2),
             ]
             .into_iter()
             .chain(value.0)
@@ -127,7 +125,7 @@ impl From<(Vec<(PlaceholderId, U256)>, U256, U256)> for Placeholders {
 /// Enumeration representing all the possible types of input operands for a basic operation
 pub enum InputOperand {
     // Input operand is a placeholder in the query
-    Placeholder(PlaceholderId),
+    Placeholder(PlaceholderIdentifier),
     // Input operand is a constant value in the query
     Constant(U256),
     /// Input operand is a column of the table: the integer stored in this variant is the index
@@ -202,7 +200,7 @@ impl BasicOperation {
     }
 
     /// Return the ids of the placeholders employed as operands of `self`, if any
-    pub(crate) fn extract_placeholder_ids(&self) -> Vec<PlaceholderId> {
+    pub(crate) fn extract_placeholder_ids(&self) -> Vec<PlaceholderIdentifier> {
         let first_id = match self.first_operand {
             InputOperand::Placeholder(p) => Some(p),
             _ => None,

--- a/verifiable-db/src/query/universal_circuit/universal_query_circuit.rs
+++ b/verifiable-db/src/query/universal_circuit/universal_query_circuit.rs
@@ -37,9 +37,7 @@ use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use super::{
     output_no_aggregation::Circuit as NoAggOutputCircuit,
     output_with_aggregation::Circuit as AggOutputCircuit,
-    universal_circuit_inputs::{
-        BasicOperation, PlaceholderId, Placeholders, ResultStructure, RowCells,
-    },
+    universal_circuit_inputs::{BasicOperation, Placeholders, ResultStructure, RowCells},
     universal_query_gadget::{
         OutputComponent, QueryBound, UniversalQueryHashInputWires, UniversalQueryHashInputs,
         UniversalQueryValueInputWires, UniversalQueryValueInputs,
@@ -236,14 +234,14 @@ where
     }
 }
 
-pub(crate) fn dummy_placeholder_id() -> PlaceholderId {
+pub(crate) fn dummy_placeholder_id() -> PlaceholderIdentifier {
     PlaceholderIdentifier::default()
 }
 
 /// Utility method to compute the placeholder hash for the placeholders provided as input, without including the
 /// query bounds on the secondary index
 pub(crate) fn placeholder_hash_without_query_bounds(
-    placeholder_ids: &[PlaceholderId],
+    placeholder_ids: &[PlaceholderIdentifier],
     placeholders: &Placeholders,
 ) -> Result<PlaceholderHash> {
     let inputs = placeholder_ids
@@ -260,7 +258,7 @@ pub(crate) fn placeholder_hash_without_query_bounds(
 
 /// Compute the placeholder hash for the placeholders and query bounds provided as input
 pub(crate) fn placeholder_hash(
-    placeholder_ids: &[PlaceholderId],
+    placeholder_ids: &[PlaceholderIdentifier],
     placeholders: &Placeholders,
     query_bounds: &QueryBounds,
 ) -> Result<PlaceholderHash> {
@@ -454,7 +452,7 @@ where
         results: &ResultStructure,
         placeholders: &Placeholders,
         query_bounds: &QueryBounds,
-    ) -> Result<[PlaceholderId; 2 * (MAX_NUM_PREDICATE_OPS + MAX_NUM_RESULT_OPS)]> {
+    ) -> Result<[PlaceholderIdentifier; 2 * (MAX_NUM_PREDICATE_OPS + MAX_NUM_RESULT_OPS)]> {
         Ok(match results.output_variant {
             Output::Aggregation => UniversalQueryHashInputs::<
                 MAX_NUM_COLUMNS,
@@ -519,7 +517,7 @@ mod tests {
             output_no_aggregation::Circuit as OutputNoAggCircuit,
             output_with_aggregation::Circuit as OutputAggCircuit,
             universal_circuit_inputs::{
-                BasicOperation, ColumnCell, InputOperand, OutputItem, PlaceholderId, Placeholders,
+                BasicOperation, ColumnCell, InputOperand, OutputItem, Placeholders,
                 ResultStructure, RowCells,
             },
             universal_query_circuit::{
@@ -618,14 +616,14 @@ mod tests {
             column_cells[2..].to_vec(),
         );
         // define placeholders
-        let first_placeholder_id = PlaceholderId::Generic(0);
+        let first_placeholder_id = PlaceholderIdentifier::Generic(0);
         let second_placeholder_id = PlaceholderIdentifier::Generic(1);
         let mut placeholders = Placeholders::new_empty(min_query_primary, max_query_primary);
         [first_placeholder_id, second_placeholder_id]
             .iter()
             .for_each(|id| placeholders.insert(*id, gen_random_u256(rng)));
         // 3-rd placeholder is the max query bound
-        let third_placeholder_id = PlaceholderId::Generic(2);
+        let third_placeholder_id = PlaceholderIdentifier::Generic(2);
         placeholders.insert(third_placeholder_id, max_query_secondary);
 
         // build predicate operations
@@ -987,14 +985,14 @@ mod tests {
             column_cells[2..].to_vec(),
         );
         // define placeholders
-        let first_placeholder_id = PlaceholderId::Generic(0);
+        let first_placeholder_id = PlaceholderIdentifier::Generic(0);
         let second_placeholder_id = PlaceholderIdentifier::Generic(1);
         let mut placeholders = Placeholders::new_empty(min_query_primary, max_query_primary);
         [first_placeholder_id, second_placeholder_id]
             .iter()
             .for_each(|id| placeholders.insert(*id, gen_random_u256(rng)));
         // 3-rd placeholder is the min query bound
-        let third_placeholder_id = PlaceholderId::Generic(2);
+        let third_placeholder_id = PlaceholderIdentifier::Generic(2);
         placeholders.insert(third_placeholder_id, min_query_secondary);
 
         // build predicate operations

--- a/verifiable-db/src/query/universal_circuit/universal_query_gadget.rs
+++ b/verifiable-db/src/query/universal_circuit/universal_query_gadget.rs
@@ -46,8 +46,7 @@ use super::{
     },
     column_extraction::{ColumnExtractionInputWires, ColumnExtractionInputs},
     universal_circuit_inputs::{
-        BasicOperation, InputOperand, Placeholder, PlaceholderId, Placeholders, ResultStructure,
-        RowCells,
+        BasicOperation, InputOperand, Placeholder, Placeholders, ResultStructure, RowCells,
     },
     universal_query_circuit::dummy_placeholder_id,
     ComputationalHash, ComputationalHashTarget, MembershipHashTarget, PlaceholderHash,
@@ -838,7 +837,7 @@ where
         results: &ResultStructure,
         placeholders: &Placeholders,
         query_bounds: &QueryBounds,
-    ) -> Result<Vec<PlaceholderId>> {
+    ) -> Result<Vec<PlaceholderIdentifier>> {
         let hash_input_gadget = Self::new(
             &ColumnIDs::default(),
             predicate_operations,

--- a/verifiable-db/src/query/utils.rs
+++ b/verifiable-db/src/query/utils.rs
@@ -30,7 +30,7 @@ use serde::{Deserialize, Serialize};
 use super::{
     computational_hash_ids::{ColumnIDs, Identifiers, PlaceholderIdentifier},
     universal_circuit::{
-        universal_circuit_inputs::{BasicOperation, PlaceholderId, Placeholders, ResultStructure},
+        universal_circuit_inputs::{BasicOperation, Placeholders, ResultStructure},
         universal_query_circuit::{
             placeholder_hash, placeholder_hash_without_query_bounds, UniversalCircuitInput,
         },
@@ -64,7 +64,7 @@ pub enum QueryBoundSource {
     // Query bound is a constant
     Constant(U256),
     /// Query bound taken from placeholder with id
-    Placeholder(PlaceholderId),
+    Placeholder(PlaceholderIdentifier),
     /// Query bound computed with a basic operation
     Operation(BasicOperation),
 }

--- a/verifiable-db/src/query/utils.rs
+++ b/verifiable-db/src/query/utils.rs
@@ -1,4 +1,4 @@
-use std::{array, iter::once};
+use std::{array, cmp::Ordering, iter::once};
 
 use alloy::primitives::U256;
 use anyhow::Result;
@@ -72,6 +72,34 @@ pub enum QueryBoundSource {
 impl From<&QueryBoundSecondary> for QueryBoundSource {
     fn from(value: &QueryBoundSecondary) -> Self {
         value.source.clone()
+    }
+}
+
+impl PartialOrd for QueryBoundSource {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        match (self, other) {
+            (QueryBoundSource::Constant(x), QueryBoundSource::Constant(y)) => Some(x.cmp(y)),
+            (QueryBoundSource::Constant(_), QueryBoundSource::Placeholder(_))
+            | (QueryBoundSource::Constant(_), QueryBoundSource::Operation(_))
+            | (QueryBoundSource::Placeholder(_), QueryBoundSource::Constant(_)) => None,
+            (QueryBoundSource::Placeholder(p1), QueryBoundSource::Placeholder(p2)) => {
+                if p1 == p2 {
+                    Some(Ordering::Equal)
+                } else {
+                    None
+                }
+            }
+            (QueryBoundSource::Placeholder(_), QueryBoundSource::Operation(_))
+            | (QueryBoundSource::Operation(_), QueryBoundSource::Constant(_))
+            | (QueryBoundSource::Operation(_), QueryBoundSource::Placeholder(_)) => None,
+            (QueryBoundSource::Operation(op1), QueryBoundSource::Operation(op2)) => {
+                if op1 == op2 {
+                    Some(Ordering::Equal)
+                } else {
+                    None
+                }
+            }
+        }
     }
 }
 

--- a/verifiable-db/src/revelation/placeholders_check.rs
+++ b/verifiable-db/src/revelation/placeholders_check.rs
@@ -4,8 +4,7 @@
 use crate::query::{
     computational_hash_ids::PlaceholderIdentifier,
     universal_circuit::{
-        universal_circuit_inputs::{PlaceholderId, Placeholders},
-        universal_query_gadget::QueryBound,
+        universal_circuit_inputs::Placeholders, universal_query_gadget::QueryBound,
     },
     utils::QueryBounds,
 };
@@ -155,7 +154,7 @@ impl<const PH: usize, const PP: usize> CheckPlaceholderGadget<PH, PP> {
     pub(crate) fn new(
         query_bounds: &QueryBounds,
         placeholders: &Placeholders,
-        placeholder_hash_ids: [PlaceholderId; PP],
+        placeholder_hash_ids: [PlaceholderIdentifier; PP],
     ) -> Result<Self> {
         let num_placeholders = placeholders.len();
         ensure!(
@@ -219,12 +218,12 @@ impl<const PH: usize, const PP: usize> CheckPlaceholderGadget<PH, PP> {
             .into_iter()
             .flat_map(|query_bound| {
                 [
-                    compute_checked_placeholder_for_id(PlaceholderId::from_fields(&[query_bound
-                        .operation
-                        .placeholder_ids[0]])),
-                    compute_checked_placeholder_for_id(PlaceholderId::from_fields(&[query_bound
-                        .operation
-                        .placeholder_ids[1]])),
+                    compute_checked_placeholder_for_id(PlaceholderIdentifier::from_fields(&[
+                        query_bound.operation.placeholder_ids[0],
+                    ])),
+                    compute_checked_placeholder_for_id(PlaceholderIdentifier::from_fields(&[
+                        query_bound.operation.placeholder_ids[1],
+                    ])),
                 ]
             })
             .collect::<Result<Vec<_>>>()?;


### PR DESCRIPTION
This PR adds a step to the assembler to check that the primary index is constrained at least within the `[MIN_BLOCK, MAX_BLOCK]` interval.

It also removes a useless alias of `PlaceholderIdentifier`.