### PR TITLE
Change Metadata Digest for Tables Supporting Empy Extraction

### DIFF
--- a/mp2-v1/src/values_extraction/mod.rs
+++ b/mp2-v1/src/values_extraction/mod.rs
@@ -2,7 +2,9 @@ use crate::api::SlotInput;
 
 use gadgets::{
     column_info::{ExtractedColumnInfo, InputColumnInfo},
-    metadata_gadget::TableMetadata,
+    metadata_gadget::{
+        EmptyableTableMetadata, NonEmptyableTableMetadata, TableColumns, TableMetadata,
+    },
 };
 use itertools::Itertools;
 
@@ -137,7 +139,7 @@ impl StorageSlotInfo {
         contract_address: &Address,
         chain_id: u64,
         extra: Vec<u8>,
-    ) -> TableMetadata {
+    ) -> TableColumns {
         let slot = self.slot().slot();
         let num_mapping_keys = self.slot().mapping_keys().len();
 
@@ -177,7 +179,10 @@ impl StorageSlotInfo {
             _ => vec![],
         };
 
-        TableMetadata::new(&input_columns, self.table_info())
+        TableColumns {
+            input_columns,
+            extracted_columns: self.table_info().to_vec(),
+        }
     }
 }
 
@@ -202,7 +207,7 @@ pub const GAS_USED_PREFIX: &[u8] = b"gas_used";
 pub const GAS_USED_NAME: &str = "gas_used";
 
 impl<const NO_TOPICS: usize, const MAX_DATA_WORDS: usize>
-    From<EventLogInfo<NO_TOPICS, MAX_DATA_WORDS>> for TableMetadata
+    From<EventLogInfo<NO_TOPICS, MAX_DATA_WORDS>> for EmptyableTableMetadata
 {
     fn from(event: EventLogInfo<NO_TOPICS, MAX_DATA_WORDS>) -> Self {
         let packed_sig = event.event_signature.pack(Endianness::Big);
@@ -574,8 +579,8 @@ pub fn row_unique_data_for_receipt_leaf(tx_index: &[u8], gas_used: &[u8]) -> Has
 }
 
 /// Function to compute a storage value digest
-fn storage_value_digest(
-    table_metadata: &TableMetadata,
+fn storage_value_digest<const CAN_BE_EMPTY: bool>(
+    table_metadata: &TableMetadata<CAN_BE_EMPTY>,
     keys: &[&[u8]],
     value: &[u8; MAPPING_LEAF_VALUE_LEN],
     slot: &StorageSlotInfo,
@@ -587,17 +592,17 @@ fn storage_value_digest(
     // Panic if the number of keys provided is not equal to the number of input columns
     assert_eq!(
         keys.len(),
-        table_metadata.input_columns.len(),
+        table_metadata.input_columns().len(),
         "Number of keys: {}, does not equal the number of input columns: {}",
         keys.len(),
-        table_metadata.input_columns.len()
+        table_metadata.input_columns().len()
     );
     table_metadata.storage_values_digest(padded_keys.as_slice(), value.as_slice(), slot.slot())
 }
 
 /// Compute the metadata digest for single variable leaf.
 pub fn compute_leaf_single_metadata_digest(slot_info: &StorageSlotInfo) -> Digest {
-    TableMetadata::new(&[], slot_info.table_info()).digest()
+    NonEmptyableTableMetadata::new(&[], slot_info.table_info()).digest()
 }
 
 /// Compute the values digest for single variable leaf.
@@ -605,8 +610,36 @@ pub fn compute_leaf_single_values_digest(
     slot_info: &StorageSlotInfo,
     value: [u8; MAPPING_LEAF_VALUE_LEN],
 ) -> Digest {
-    let table_metadata = TableMetadata::new(&[], slot_info.table_info());
+    let table_metadata = NonEmptyableTableMetadata::new(&[], slot_info.table_info());
     storage_value_digest(&table_metadata, &[], &value, slot_info)
+}
+
+/// Internal method to compute the metadata digest for mapping variable.
+/// The const generic flag is employed to specify whether the final metadata
+/// digest is computed or the intermediate one to be provided as input to the
+/// empty circuit, i.e., the circuit to be employed for value extraction in
+/// case no mapping entries are found for the current block
+fn compute_mapping_metadata_digest<const EMPTY_CIRCUIT: bool>(
+    slot_info: &StorageSlotInfo,
+    key_id: ColumnId,
+) -> Digest {
+    let input_column = InputColumnInfo::new(&[slot_info.slot().slot()], key_id, KEY_ID_PREFIX);
+    let metadata = EmptyableTableMetadata::new(&[input_column], slot_info.table_info());
+    if EMPTY_CIRCUIT {
+        metadata.digest_for_empty_circuit()
+    } else {
+        metadata.digest()
+    }
+}
+
+/// Compute the metadata digest for mapping variable, which is needed as input
+/// for the circuit to be employed for value extraction roof in case no
+/// mapping entires are found in the current block
+pub fn compute_mapping_metadata_digest_for_empty_circuit(
+    slot_info: &StorageSlotInfo,
+    key_id: ColumnId,
+) -> Digest {
+    compute_mapping_metadata_digest::<true>(slot_info, key_id)
 }
 
 /// Compute the metadata digest for mapping variable leaf.
@@ -614,8 +647,7 @@ pub fn compute_leaf_mapping_metadata_digest(
     slot_info: &StorageSlotInfo,
     key_id: ColumnId,
 ) -> Digest {
-    let input_column = InputColumnInfo::new(&[slot_info.slot().slot()], key_id, KEY_ID_PREFIX);
-    TableMetadata::new(&[input_column], slot_info.table_info()).digest()
+    compute_mapping_metadata_digest::<false>(slot_info, key_id)
 }
 
 /// Compute the values digest for mapping variable leaf.
@@ -626,7 +658,7 @@ pub fn compute_leaf_mapping_values_digest(
     key_id: ColumnId,
 ) -> Digest {
     let input_column = InputColumnInfo::new(&[slot_info.slot().slot()], key_id, KEY_ID_PREFIX);
-    let table_metadata = TableMetadata::new(&[input_column], slot_info.table_info());
+    let table_metadata = EmptyableTableMetadata::new(&[input_column], slot_info.table_info());
     storage_value_digest(
         &table_metadata,
         &[mapping_key.as_slice()],
@@ -635,8 +667,12 @@ pub fn compute_leaf_mapping_values_digest(
     )
 }
 
-/// Compute the metadata digest for mapping of mappings leaf.
-pub fn compute_leaf_mapping_of_mappings_metadata_digest(
+/// Internal method to compute the metadata digest for mapping of mappings variable.
+/// The const generic flag is employed to specify whether the final metadata
+/// digest is computed or the intermediate one to be provided as input to the
+/// empty circuit, i.e., the circuit to be employed for value extraction in
+/// case no mapping entries are found for the current block
+fn compute_mapping_of_mappings_metadata_digest<const EMPTY_CIRCUIT: bool>(
     slot_info: &StorageSlotInfo,
     outer_key_id: ColumnId,
     inner_key_id: ColumnId,
@@ -651,11 +687,35 @@ pub fn compute_leaf_mapping_of_mappings_metadata_digest(
         inner_key_id,
         INNER_KEY_ID_PREFIX,
     );
-    TableMetadata::new(
+    let metadata = EmptyableTableMetadata::new(
         &[outer_key_column, inner_key_column],
         slot_info.table_info(),
-    )
-    .digest()
+    );
+    if EMPTY_CIRCUIT {
+        metadata.digest_for_empty_circuit()
+    } else {
+        metadata.digest()
+    }
+}
+
+/// Compute the metadata digest for mapping of mappings variable, which is needed
+/// as input for the circuit to be employed for value extraction roof in case no
+/// mapping entires are found in the current block
+pub fn compute_mapping_of_mappings_metadata_digest_for_empty_circuit(
+    slot_info: &StorageSlotInfo,
+    outer_key_id: ColumnId,
+    inner_key_id: ColumnId,
+) -> Digest {
+    compute_mapping_of_mappings_metadata_digest::<true>(slot_info, outer_key_id, inner_key_id)
+}
+
+/// Compute the metadata digest for mapping of mappings leaf.
+pub fn compute_leaf_mapping_of_mappings_metadata_digest(
+    slot_info: &StorageSlotInfo,
+    outer_key_id: ColumnId,
+    inner_key_id: ColumnId,
+) -> Digest {
+    compute_mapping_of_mappings_metadata_digest::<false>(slot_info, outer_key_id, inner_key_id)
 }
 
 /// Compute the values digest for mapping of mappings leaf.
@@ -677,7 +737,7 @@ pub fn compute_leaf_mapping_of_mappings_values_digest(
         inner_key_id,
         INNER_KEY_ID_PREFIX,
     );
-    let table_metadata = TableMetadata::new(
+    let table_metadata = EmptyableTableMetadata::new(
         &[outer_key_column, inner_key_column],
         slot_info.table_info(),
     );
@@ -688,6 +748,18 @@ pub fn compute_leaf_mapping_of_mappings_values_digest(
         &value,
         slot_info,
     )
+}
+
+/// Compute the metadata digest for a receipt leaf, which is needed
+/// as input for the circuit to be employed for value extraction roof in case no
+/// events to be extracted are found in the current block
+pub fn compute_receipt_metadata_digest_for_empty_circuit<
+    const NO_TOPICS: usize,
+    const MAX_DATA_WORDS: usize,
+>(
+    event: &EventLogInfo<NO_TOPICS, MAX_DATA_WORDS>,
+) -> Digest {
+    TableMetadata::from(*event).digest_for_empty_circuit()
 }
 
 /// Compute the metadata digest for a Receipt leaf

--- a/mp2-v1/src/values_extraction/mod.rs
+++ b/mp2-v1/src/values_extraction/mod.rs
@@ -29,7 +29,7 @@ use std::iter::once;
 
 pub mod api;
 mod branch;
-mod dummy;
+mod empty;
 mod extension;
 pub mod gadgets;
 mod leaf_mapping;

--- a/mp2-v1/src/values_extraction/planner/receipts.rs
+++ b/mp2-v1/src/values_extraction/planner/receipts.rs
@@ -140,7 +140,7 @@ impl<const NO_TOPICS: usize, const MAX_DATA_WORDS: usize> Extractable
             InputEnum::Dummy(block_hash) => {
                 let metadata_digest =
                     compute_receipt_metadata_digest_for_empty_circuit(extractable);
-                CircuitInput::new_dummy(*block_hash, metadata_digest)
+                CircuitInput::new_empty_extraction(*block_hash, metadata_digest)
             }
         }
     }

--- a/mp2-v1/src/values_extraction/planner/receipts.rs
+++ b/mp2-v1/src/values_extraction/planner/receipts.rs
@@ -10,9 +10,10 @@ use serde::{Deserialize, Serialize};
 
 use std::collections::HashMap;
 
+use crate::values_extraction::compute_receipt_metadata_digest_for_empty_circuit;
+
 use super::{
-    super::gadgets::metadata_gadget::TableMetadata, CircuitInput, Extractable,
-    ExtractionUpdatePlan, InputEnum, MP2PlannerError, ProofData,
+    CircuitInput, Extractable, ExtractionUpdatePlan, InputEnum, MP2PlannerError, ProofData,
 };
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -137,8 +138,8 @@ impl<const NO_TOPICS: usize, const MAX_DATA_WORDS: usize> Extractable
                 CircuitInput::new_receipt_leaf(node, *tx_index, extractable)
             }
             InputEnum::Dummy(block_hash) => {
-                let metadata = TableMetadata::from_event_info(extractable);
-                let metadata_digest = metadata.digest();
+                let metadata_digest =
+                    compute_receipt_metadata_digest_for_empty_circuit(extractable);
                 CircuitInput::new_dummy(*block_hash, metadata_digest)
             }
         }


### PR DESCRIPTION
This PR adds to metadata digest a constant identifier for tables that support empty extraction, i.e., tables for which it may happen that there are no values to be extracted for a given block. This identifier allows to prevent the prover from using the special empty extraction circuit (which allows to claim that were no values extracted in a given block) in tables where it can never happen that there are no values to be extracted. 