### PR TITLE
fix: do not crash on queries without cell tree

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2359,44 +2359,18 @@ dependencies = [
 
 [[package]]
 name = "ethers"
-version = "2.0.13"
-source = "git+https://github.com/Lagrange-Labs/ethers-rs?branch=get-proof-0x#07ee38ea0cbdade798717805af28b6e4779071f8"
-dependencies = [
- "ethers-addressbook 2.0.13",
- "ethers-contract 2.0.13",
- "ethers-core 2.0.13",
- "ethers-etherscan 2.0.13",
- "ethers-middleware 2.0.13",
- "ethers-providers 2.0.13",
- "ethers-signers 2.0.13",
- "ethers-solc 2.0.13",
-]
-
-[[package]]
-name = "ethers"
 version = "2.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "816841ea989f0c69e459af1cf23a6b0033b19a55424a1ea3a30099becdb8dec0"
 dependencies = [
- "ethers-addressbook 2.0.14",
- "ethers-contract 2.0.14",
- "ethers-core 2.0.14",
- "ethers-etherscan 2.0.14",
- "ethers-middleware 2.0.14",
- "ethers-providers 2.0.14",
- "ethers-signers 2.0.14",
- "ethers-solc 2.0.14",
-]
-
-[[package]]
-name = "ethers-addressbook"
-version = "2.0.13"
-source = "git+https://github.com/Lagrange-Labs/ethers-rs?branch=get-proof-0x#07ee38ea0cbdade798717805af28b6e4779071f8"
-dependencies = [
- "ethers-core 2.0.13",
- "once_cell",
- "serde",
- "serde_json",
+ "ethers-addressbook",
+ "ethers-contract",
+ "ethers-core",
+ "ethers-etherscan",
+ "ethers-middleware",
+ "ethers-providers",
+ "ethers-signers",
+ "ethers-solc",
 ]
 
 [[package]]
@@ -2405,28 +2379,10 @@ version = "2.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5495afd16b4faa556c3bba1f21b98b4983e53c1755022377051a975c3b021759"
 dependencies = [
- "ethers-core 2.0.14",
+ "ethers-core",
  "once_cell",
  "serde",
  "serde_json",
-]
-
-[[package]]
-name = "ethers-contract"
-version = "2.0.13"
-source = "git+https://github.com/Lagrange-Labs/ethers-rs?branch=get-proof-0x#07ee38ea0cbdade798717805af28b6e4779071f8"
-dependencies = [
- "const-hex",
- "ethers-contract-abigen 2.0.13",
- "ethers-contract-derive 2.0.13",
- "ethers-core 2.0.13",
- "ethers-providers 2.0.13",
- "futures-util",
- "once_cell",
- "pin-project",
- "serde",
- "serde_json",
- "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -2436,39 +2392,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fceafa3578c836eeb874af87abacfb041f92b4da0a78a5edd042564b8ecdaaa"
 dependencies = [
  "const-hex",
- "ethers-contract-abigen 2.0.14",
- "ethers-contract-derive 2.0.14",
- "ethers-core 2.0.14",
- "ethers-providers 2.0.14",
+ "ethers-contract-abigen",
+ "ethers-contract-derive",
+ "ethers-core",
+ "ethers-providers",
  "futures-util",
  "once_cell",
  "pin-project",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
-]
-
-[[package]]
-name = "ethers-contract-abigen"
-version = "2.0.13"
-source = "git+https://github.com/Lagrange-Labs/ethers-rs?branch=get-proof-0x#07ee38ea0cbdade798717805af28b6e4779071f8"
-dependencies = [
- "Inflector",
- "const-hex",
- "dunce",
- "ethers-core 2.0.13",
- "ethers-etherscan 2.0.13",
- "eyre",
- "prettyplease",
- "proc-macro2",
- "quote",
- "regex",
- "reqwest 0.11.27",
- "serde",
- "serde_json",
- "syn 2.0.98",
- "toml",
- "walkdir",
 ]
 
 [[package]]
@@ -2480,8 +2413,8 @@ dependencies = [
  "Inflector",
  "const-hex",
  "dunce",
- "ethers-core 2.0.14",
- "ethers-etherscan 2.0.14",
+ "ethers-core",
+ "ethers-etherscan",
  "eyre",
  "prettyplease",
  "proc-macro2",
@@ -2497,62 +2430,18 @@ dependencies = [
 
 [[package]]
 name = "ethers-contract-derive"
-version = "2.0.13"
-source = "git+https://github.com/Lagrange-Labs/ethers-rs?branch=get-proof-0x#07ee38ea0cbdade798717805af28b6e4779071f8"
-dependencies = [
- "Inflector",
- "const-hex",
- "ethers-contract-abigen 2.0.13",
- "ethers-core 2.0.13",
- "proc-macro2",
- "quote",
- "serde_json",
- "syn 2.0.98",
-]
-
-[[package]]
-name = "ethers-contract-derive"
 version = "2.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87689dcabc0051cde10caaade298f9e9093d65f6125c14575db3fd8c669a168f"
 dependencies = [
  "Inflector",
  "const-hex",
- "ethers-contract-abigen 2.0.14",
- "ethers-core 2.0.14",
+ "ethers-contract-abigen",
+ "ethers-core",
  "proc-macro2",
  "quote",
  "serde_json",
  "syn 2.0.98",
-]
-
-[[package]]
-name = "ethers-core"
-version = "2.0.13"
-source = "git+https://github.com/Lagrange-Labs/ethers-rs?branch=get-proof-0x#07ee38ea0cbdade798717805af28b6e4779071f8"
-dependencies = [
- "arrayvec",
- "bytes",
- "cargo_metadata",
- "chrono",
- "const-hex",
- "elliptic-curve",
- "ethabi",
- "generic-array",
- "k256",
- "num_enum",
- "once_cell",
- "open-fastrlp",
- "rand 0.8.5",
- "rlp",
- "serde",
- "serde_json",
- "strum",
- "syn 2.0.98",
- "tempfile",
- "thiserror 1.0.69",
- "tiny-keccak",
- "unicode-xid",
 ]
 
 [[package]]
@@ -2587,58 +2476,18 @@ dependencies = [
 
 [[package]]
 name = "ethers-etherscan"
-version = "2.0.13"
-source = "git+https://github.com/Lagrange-Labs/ethers-rs?branch=get-proof-0x#07ee38ea0cbdade798717805af28b6e4779071f8"
-dependencies = [
- "chrono",
- "ethers-core 2.0.13",
- "reqwest 0.11.27",
- "semver 1.0.25",
- "serde",
- "serde_json",
- "thiserror 1.0.69",
- "tracing",
-]
-
-[[package]]
-name = "ethers-etherscan"
 version = "2.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e79e5973c26d4baf0ce55520bd732314328cabe53193286671b47144145b9649"
 dependencies = [
  "chrono",
- "ethers-core 2.0.14",
+ "ethers-core",
  "reqwest 0.11.27",
  "semver 1.0.25",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
  "tracing",
-]
-
-[[package]]
-name = "ethers-middleware"
-version = "2.0.13"
-source = "git+https://github.com/Lagrange-Labs/ethers-rs?branch=get-proof-0x#07ee38ea0cbdade798717805af28b6e4779071f8"
-dependencies = [
- "async-trait",
- "auto_impl",
- "ethers-contract 2.0.13",
- "ethers-core 2.0.13",
- "ethers-providers 2.0.13",
- "ethers-signers 2.0.13",
- "futures-channel",
- "futures-locks",
- "futures-util",
- "instant",
- "reqwest 0.11.27",
- "serde",
- "serde_json",
- "thiserror 1.0.69",
- "tokio",
- "tracing",
- "tracing-futures",
- "url",
 ]
 
 [[package]]
@@ -2649,11 +2498,11 @@ checksum = "48f9fdf09aec667c099909d91908d5eaf9be1bd0e2500ba4172c1d28bfaa43de"
 dependencies = [
  "async-trait",
  "auto_impl",
- "ethers-contract 2.0.14",
- "ethers-core 2.0.14",
- "ethers-etherscan 2.0.14",
- "ethers-providers 2.0.14",
- "ethers-signers 2.0.14",
+ "ethers-contract",
+ "ethers-core",
+ "ethers-etherscan",
+ "ethers-providers",
+ "ethers-signers",
  "futures-channel",
  "futures-locks",
  "futures-util",
@@ -2666,42 +2515,6 @@ dependencies = [
  "tracing",
  "tracing-futures",
  "url",
-]
-
-[[package]]
-name = "ethers-providers"
-version = "2.0.13"
-source = "git+https://github.com/Lagrange-Labs/ethers-rs?branch=get-proof-0x#07ee38ea0cbdade798717805af28b6e4779071f8"
-dependencies = [
- "async-trait",
- "auto_impl",
- "base64 0.21.7",
- "bytes",
- "const-hex",
- "enr",
- "ethers-core 2.0.13",
- "futures-core",
- "futures-timer",
- "futures-util",
- "hashers",
- "http 0.2.12",
- "instant",
- "jsonwebtoken",
- "once_cell",
- "pin-project",
- "reqwest 0.11.27",
- "serde",
- "serde_json",
- "thiserror 1.0.69",
- "tokio",
- "tokio-tungstenite",
- "tracing",
- "tracing-futures",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
- "ws_stream_wasm",
 ]
 
 [[package]]
@@ -2716,7 +2529,7 @@ dependencies = [
  "bytes",
  "const-hex",
  "enr",
- "ethers-core 2.0.14",
+ "ethers-core",
  "futures-core",
  "futures-timer",
  "futures-util",
@@ -2743,24 +2556,6 @@ dependencies = [
 
 [[package]]
 name = "ethers-signers"
-version = "2.0.13"
-source = "git+https://github.com/Lagrange-Labs/ethers-rs?branch=get-proof-0x#07ee38ea0cbdade798717805af28b6e4779071f8"
-dependencies = [
- "async-trait",
- "coins-bip32",
- "coins-bip39",
- "const-hex",
- "elliptic-curve",
- "eth-keystore",
- "ethers-core 2.0.13",
- "rand 0.8.5",
- "sha2",
- "thiserror 1.0.69",
- "tracing",
-]
-
-[[package]]
-name = "ethers-signers"
 version = "2.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "228875491c782ad851773b652dd8ecac62cda8571d3bc32a5853644dd26766c2"
@@ -2771,42 +2566,11 @@ dependencies = [
  "const-hex",
  "elliptic-curve",
  "eth-keystore",
- "ethers-core 2.0.14",
+ "ethers-core",
  "rand 0.8.5",
  "sha2",
  "thiserror 1.0.69",
  "tracing",
-]
-
-[[package]]
-name = "ethers-solc"
-version = "2.0.13"
-source = "git+https://github.com/Lagrange-Labs/ethers-rs?branch=get-proof-0x#07ee38ea0cbdade798717805af28b6e4779071f8"
-dependencies = [
- "cfg-if",
- "const-hex",
- "dirs",
- "dunce",
- "ethers-core 2.0.13",
- "glob",
- "home",
- "md-5 0.10.6",
- "num_cpus",
- "once_cell",
- "path-slash",
- "rayon",
- "regex",
- "semver 1.0.25",
- "serde",
- "serde_json",
- "solang-parser",
- "svm-rs",
- "thiserror 1.0.69",
- "tiny-keccak",
- "tokio",
- "tracing",
- "walkdir",
- "yansi",
 ]
 
 [[package]]
@@ -2819,7 +2583,7 @@ dependencies = [
  "const-hex",
  "dirs",
  "dunce",
- "ethers-core 2.0.14",
+ "ethers-core",
  "glob",
  "home",
  "md-5 0.10.6",
@@ -4165,7 +3929,7 @@ source = "git+https://github.com/Lagrange-Labs/lgn-coprocessor.git?branch=main#5
 dependencies = [
  "alloy-primitives 0.8.21",
  "derive-debug-plus",
- "ethers 2.0.14",
+ "ethers",
  "mp2_common 1.2.1",
  "mp2_v1 1.2.1",
  "object_store",
@@ -4185,7 +3949,7 @@ dependencies = [
  "bincode",
  "bytes",
  "checksums",
- "ethers 2.0.14",
+ "ethers",
  "groth16_framework 1.2.1",
  "lgn-messages",
  "metrics",
@@ -4394,7 +4158,6 @@ dependencies = [
  "derive_more 2.0.1",
  "eth_trie",
  "ethereum-types",
- "ethers 2.0.13",
  "git-version",
  "hashbrown 0.15.2",
  "hex",
@@ -5266,7 +5029,7 @@ dependencies = [
  "dotenv",
  "ed25519-dalek",
  "env_logger 0.10.2",
- "ethers 2.0.14",
+ "ethers",
  "ff",
  "futures 0.3.31",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,11 +99,6 @@ tokio = { version = "1.34", features = [
 tokio-postgres = { version = "0.7", features = ["with-chrono-0_4"] }
 tracing = "0.1.40"
 
-# just for test
-ethers = { git = "https://github.com/Lagrange-Labs/ethers-rs", default-features = false, features = [
-  "rustls",
-], branch = "get-proof-0x" }
-
 [profile.dev]
 # Reference: https://doc.rust-lang.org/cargo/reference/profiles.html#dev
 # Proving is too slow without optimizations

--- a/mp2-common/Cargo.toml
+++ b/mp2-common/Cargo.toml
@@ -27,7 +27,6 @@ serde.workspace = true
 sha3.workspace = true
 
 [dev-dependencies]
-ethers.workspace = true
 hex.workspace = true
 rand.workspace = true
 rstest.workspace = true

--- a/mp2-common/src/eth.rs
+++ b/mp2-common/src/eth.rs
@@ -275,11 +275,6 @@ mod test {
     use std::str::FromStr;
 
     use alloy::{primitives::Bytes, providers::ProviderBuilder};
-    use ethereum_types::U64;
-    use ethers::{
-        providers::{Http, Middleware},
-        types::BlockNumber,
-    };
     use hashbrown::HashMap;
 
     use crate::{
@@ -480,96 +475,10 @@ mod test {
         let alloy_computed = block.header.hash_slow();
         assert_eq!(mp2_computed.as_slice(), alloy_computed.as_slice());
 
-        // CHECK RLP ENCODING FROM ETHERS MMODIF AND ALLOY
-        let ethers_provider = ethers::providers::Provider::<Http>::try_from(url)
-            .expect("could not instantiate HTTP Provider");
-        let ethers_block = ethers_provider
-            .get_block_with_txs(BlockNumber::Number(U64::from(block.header.number)))
-            .await?
-            .unwrap();
-        // sanity check that ethers manual rlp implementation works
-        assert_eq!(block.header.hash.as_slice(), ethers_block.block_hash());
-        let ethers_rlp = ethers_block.rlp();
-        let alloy_rlp = block.header.rlp();
-        assert_eq!(ethers_rlp, alloy_rlp);
-        let manual_alloy_rlp = block.header.rlp();
-        let ethers_stream = rlp::Rlp::new(&ethers_rlp);
-        let manual_stream = rlp::Rlp::new(&manual_alloy_rlp);
-        compare_rlp(ethers_stream, manual_stream);
-        assert_eq!(ethers_rlp, manual_alloy_rlp);
-
         let previous_computed = previous_block.block_hash();
         assert_eq!(&previous_computed, block.header.parent_hash.as_slice());
         let alloy_given = block.header.hash;
         assert_eq!(alloy_given, alloy_computed);
         Ok(())
-    }
-
-    fn compare_rlp<'a>(a: rlp::Rlp<'a>, b: rlp::Rlp<'a>) {
-        let ap = a.payload_info().unwrap();
-        let bp = b.payload_info().unwrap();
-        assert_eq!(
-            a.item_count().unwrap(),
-            b.item_count().unwrap(),
-            "not same item count in  list"
-        );
-        assert_eq!(
-            ap.header_len, bp.header_len,
-            "payloads different header len"
-        );
-        assert_eq!(a.is_list(), b.is_list());
-        println!(
-            "Item count for block RLP => a = {}, b = {}",
-            a.item_count().unwrap(),
-            b.item_count().unwrap()
-        );
-        for i in 0..a.item_count().unwrap() {
-            let ae = a.at(i).unwrap().as_raw();
-            let be = b.at(i).unwrap().as_raw();
-            println!("Checking element {} - len {} vs {}", i, ae.len(), be.len());
-            assert_eq!(ae, be, "elements not the same at index {i}");
-        }
-        // FAILING
-        assert_eq!(ap.value_len, bp.value_len, "payloads different value len");
-    }
-    /// TEST to compare alloy with ethers
-    pub struct RLPBlock<'a, X>(pub &'a ethers::types::Block<X>);
-    impl<X> BlockUtil for ethers::types::Block<X> {
-        fn rlp(&self) -> Vec<u8> {
-            let rlp = RLPBlock(self);
-            rlp::encode(&rlp).to_vec()
-        }
-    }
-    impl<X> rlp::Encodable for RLPBlock<'_, X> {
-        fn rlp_append(&self, s: &mut rlp::RlpStream) {
-            s.begin_unbounded_list();
-            s.append(&self.0.parent_hash);
-            s.append(&self.0.uncles_hash);
-            s.append(&self.0.author.unwrap_or_default());
-            s.append(&self.0.state_root);
-            s.append(&self.0.transactions_root);
-            s.append(&self.0.receipts_root);
-            s.append(&self.0.logs_bloom.unwrap_or_default());
-            s.append(&self.0.difficulty);
-            s.append(&self.0.number.unwrap_or_default());
-            s.append(&self.0.gas_limit);
-            s.append(&self.0.gas_used);
-            s.append(&self.0.timestamp);
-            s.append(&self.0.extra_data.to_vec());
-            s.append(&self.0.mix_hash.unwrap_or_default());
-            s.append(&self.0.nonce.unwrap_or_default());
-            rlp_opt(s, &self.0.base_fee_per_gas);
-            rlp_opt(s, &self.0.withdrawals_root);
-            rlp_opt(s, &self.0.blob_gas_used);
-            rlp_opt(s, &self.0.excess_blob_gas);
-            rlp_opt(s, &self.0.parent_beacon_block_root);
-            s.finalize_unbounded_list();
-        }
-    }
-    /// Extracted from ether-rs
-    pub(crate) fn rlp_opt<T: rlp::Encodable>(rlp: &mut rlp::RlpStream, opt: &Option<T>) {
-        if let Some(inner) = opt {
-            rlp.append(inner);
-        }
     }
 }

--- a/mp2-v1/src/indexing/cell.rs
+++ b/mp2-v1/src/indexing/cell.rs
@@ -101,6 +101,13 @@ impl<PrimaryIndex: Default> MerkleCell<PrimaryIndex> {
             ..Default::default()
         }
     }
+
+    pub fn new_empty() -> Self {
+        Self {
+            hash: HashOutput::from(*empty_poseidon_hash()),
+            ..Default::default()
+        }
+    }
 }
 
 impl<

--- a/mp2-v1/src/indexing/mod.rs
+++ b/mp2-v1/src/indexing/mod.rs
@@ -1,6 +1,6 @@
 use crate::indexing::{index::IndexNode, row::RowPayload};
 use alloy::primitives::U256;
-use mp2_common::types::HashOutput;
+use mp2_common::{poseidon::empty_poseidon_hash, types::HashOutput};
 
 pub mod block;
 pub mod cell;
@@ -37,7 +37,8 @@ impl<T: Eq + Default + std::fmt::Debug + Clone> LagrangeNode for RowPayload<T> {
     }
 
     fn embedded_hash(&self) -> HashOutput {
-        self.cell_root_hash.unwrap()
+        self.cell_root_hash
+            .unwrap_or(HashOutput::from(*empty_poseidon_hash()))
     }
 }
 

--- a/mp2-v1/src/indexing/row.rs
+++ b/mp2-v1/src/indexing/row.rs
@@ -161,13 +161,13 @@ pub struct RowPayload<PrimaryIndex: PartialEq + Eq + Default> {
     /// Storing the hash of the root of the cells tree. One could get it as well from the proof
     /// but it requires loading the proof, so when building the hashing structure it's best
     /// to keep it at hand directly.
-    pub cell_root_hash: Option<HashOutput>,
+    pub(crate) cell_root_hash: Option<HashOutput>,
     /// Information needed to retrieve the cells root proof belonging to this row
     /// From the column ID, one can search in the cell collection to find the corresponding
     /// value and primary index, necessary to fetch the corresponding proof.
-    pub cell_root_column: Option<ColumnID>,
+    pub(crate) cell_root_column: Option<ColumnID>,
     /// Information needed to retrieve the cells root proof belonging to this row
-    pub cell_root_key: Option<CellTreeKey>,
+    pub cell_root_key: CellTreeKey,
     /// Min sec. index value of the subtree below this node
     pub min: U256,
     /// Max sec. index value "  "   "       "     "    "
@@ -189,7 +189,7 @@ impl<PrimaryIndex: std::fmt::Debug + Clone + Default + PartialEq + Eq> RowPayloa
         secondary_index: ColumnID,
         cell_tree_hash: Option<HashOutput>,
         cell_root_column: Option<ColumnID>,
-        cell_root_key: Option<CellTreeKey>,
+        cell_root_key: CellTreeKey,
     ) -> Self {
         RowPayload {
             cells,

--- a/mp2-v1/tests/common/cases/query/aggregated_queries.rs
+++ b/mp2-v1/tests/common/cases/query/aggregated_queries.rs
@@ -23,7 +23,6 @@ use futures::{stream, FutureExt, StreamExt};
 use itertools::Itertools;
 use log::*;
 use mp2_common::{
-    poseidon::empty_poseidon_hash,
     proof::{deserialize_proof, ProofWithVK},
     types::HashOutput,
     C, D, F,
@@ -35,6 +34,7 @@ use mp2_v1::{
         block::BlockPrimaryIndex,
         cell::MerkleCell,
         row::{Row, RowPayload, RowTreeKey},
+        LagrangeNode,
     },
     query::{
         batching_planner::{generate_chunks_and_update_tree, UTForChunkProofs, UTKey},
@@ -855,9 +855,7 @@ async fn check_correct_cells_tree(
     payload: &RowPayload<BlockPrimaryIndex>,
 ) -> Result<()> {
     let local_cells = all_cells.to_vec();
-    let expected_cells_root = payload
-        .cell_root_hash
-        .unwrap_or(HashOutput::from(*empty_poseidon_hash()));
+    let expected_cells_root = payload.embedded_hash();
     let mut tree = indexing::cell::new_tree().await;
     tree.in_transaction(|t| {
         async move {

--- a/mp2-v1/tests/common/cases/query/mod.rs
+++ b/mp2-v1/tests/common/cases/query/mod.rs
@@ -5,7 +5,7 @@ use aggregated_queries::{
     cook_query_unique_secondary_index, prove_query as prove_aggregation_query,
 };
 use alloy::primitives::U256;
-use anyhow::{Context, Result};
+use anyhow::{Context, Ok, Result};
 use itertools::Itertools;
 use log::info;
 use mp2_v1::{
@@ -105,8 +105,9 @@ pub(crate) struct QueryPlanner<'a> {
 
 pub async fn test_query(ctx: &mut TestContext, table: Table, t: TableInfo) -> Result<()> {
     match &t.source {
-        TableSource::Mapping(_) | TableSource::Merge(_) => query_mapping(ctx, &table, &t).await?,
-        _ => unimplemented!("yet"),
+        TableSource::Mapping(_) | TableSource::Merge(_) | TableSource::SingleValues(_) => {
+            query_mapping(ctx, &table, &t).await?
+        }
     }
     Ok(())
 }


### PR DESCRIPTION
This PR fixes mp2-v1 to support running queries over tables with an empty cells tree. To actually test such queries, a test case is
also added to the integration test, building a table with only indexed tables and running queries over such a table. 