### PR TITLE
fix: ensure max depth in scapegoat tree

### DIFF
--- a/mp2-v1/tests/common/table.rs
+++ b/mp2-v1/tests/common/table.rs
@@ -31,7 +31,7 @@ use verifiable_db::query::computational_hash_ids::ColumnIDs;
 use super::{
     cases::query::{
         MAX_NUM_COLUMNS, MAX_NUM_ITEMS_PER_OUTPUT, MAX_NUM_OUTPUTS, MAX_NUM_PREDICATE_OPS,
-        MAX_NUM_RESULT_OPS,
+        MAX_NUM_RESULT_OPS, ROW_TREE_MAX_DEPTH,
     },
     index_tree::MerkleIndexTree,
     rowtree::MerkleRowTree,
@@ -228,6 +228,7 @@ impl Table {
         let row_tree = ryhope::new_row_tree(
             genesis_block as Epoch,
             Alpha::new(0.8),
+            ROW_TREE_MAX_DEPTH,
             db_settings_row,
             true,
         )

--- a/ryhope/src/lib.rs
+++ b/ryhope/src/lib.rs
@@ -648,6 +648,7 @@ pub async fn new_row_tree<
 >(
     genesis_block: Epoch,
     alpha: scapegoat::Alpha,
+    max_depth: usize,
     storage_settings: S::Settings,
     reset_if_exist: bool,
 ) -> Result<MerkleTreeKvDb<scapegoat::Tree<K>, V, S>, RyhopeError> {
@@ -656,7 +657,7 @@ pub async fn new_row_tree<
     }
 
     let initial_epoch = genesis_block - 1;
-    let tree_settings = scapegoat::Tree::empty(alpha);
+    let tree_settings = scapegoat::Tree::empty(alpha, max_depth);
 
     MerkleTreeKvDb::new(
         if reset_if_exist {

--- a/ryhope/src/tests/example.rs
+++ b/ryhope/src/tests/example.rs
@@ -6,6 +6,8 @@ use crate::tree::PrintableTree;
 use crate::tree::{scapegoat, scapegoat::Alpha};
 use crate::{InitSettings, MerkleTreeKvDb};
 
+const MAX_TREE_DEPTH: usize = 10;
+
 #[tokio::test]
 async fn run() -> Result<()> {
     println!("Example to create a RowTree backed by memory storage");
@@ -15,7 +17,7 @@ async fn run() -> Result<()> {
 
     type Storage = InMemory<RowTree, V>;
     let mut tree = MerkleTreeKvDb::<RowTree, V, Storage>::new(
-        InitSettings::Reset(scapegoat::Tree::empty(Alpha::new(0.5))),
+        InitSettings::Reset(scapegoat::Tree::empty(Alpha::new(0.5), MAX_TREE_DEPTH)),
         (),
     )
     .await?;

--- a/ryhope/src/tests/trees.rs
+++ b/ryhope/src/tests/trees.rs
@@ -76,6 +76,8 @@ mod scapegoat {
     use crate::tree::scapegoat::{self, Alpha};
     use crate::tree::{PrintableTree, TreeTopology};
 
+    const MAX_TREE_DEPTH: usize = 10;
+
     fn scapegaot_in_memory<
         K: Eq
             + Hash
@@ -90,7 +92,10 @@ mod scapegoat {
     >(
         a: Alpha,
     ) -> (scapegoat::Tree<K>, InMemory<scapegoat::Tree<K>, ()>) {
-        (Default::default(), InMemory::new(scapegoat::Tree::empty(a)))
+        (
+            Default::default(),
+            InMemory::new(scapegoat::Tree::empty(a, MAX_TREE_DEPTH)),
+        )
     }
 
     #[tokio::test]
@@ -139,7 +144,7 @@ mod scapegoat {
         ls.state_mut().commit_transaction().await.unwrap();
 
         assert_eq!(bbst.depth(&bs).await.unwrap(), 7);
-        assert_eq!(list.depth(&ls).await.unwrap(), 127);
+        assert_eq!(list.depth(&ls).await.unwrap(), MAX_TREE_DEPTH);
         Ok(())
     }
 

--- a/ryhope/src/tree/scapegoat.rs
+++ b/ryhope/src/tree/scapegoat.rs
@@ -144,7 +144,12 @@ pub struct State<K> {
     pub(crate) alpha: Alpha,
     /// Maximum depth of the scapegoat tree; a re-balance will be triggered if a
     /// node has a higher depth than this upper bound
+    #[serde(default = "default_max_depth")]
     pub(crate) max_depth: usize,
+}
+
+fn default_max_depth() -> usize {
+    25
 }
 
 pub struct Tree<

--- a/ryhope/src/tree/scapegoat.rs
+++ b/ryhope/src/tree/scapegoat.rs
@@ -142,6 +142,9 @@ pub struct State<K> {
     pub(crate) root: Option<K>,
     /// The α parameter of the scapegoat tree
     pub(crate) alpha: Alpha,
+    /// Maximum depth of the scapegoat tree; a re-balance will be triggered if a
+    /// node has a higher depth than this upper bound
+    pub(crate) max_depth: usize,
 }
 
 pub struct Tree<
@@ -158,11 +161,12 @@ impl<K: Debug + Sync + Clone + Eq + Hash + Ord + Serialize + for<'a> Deserialize
 impl<K: Debug + Sync + Clone + Eq + Hash + Ord + Serialize + for<'a> Deserialize<'a> + Send>
     Tree<K>
 {
-    pub fn empty(alpha: Alpha) -> State<K> {
+    pub fn empty(alpha: Alpha, max_depth: usize) -> State<K> {
         State {
             node_count: 0,
             root: None,
             alpha,
+            max_depth,
         }
     }
 
@@ -854,9 +858,10 @@ impl<K: Debug + Sync + Clone + Eq + Hash + Ord + Serialize + for<'a> Deserialize
         node_count: usize,
         s: &mut S,
     ) -> Result<usize, RyhopeError> {
-        Ok((node_count as f32)
-            .log(s.state().fetch().await?.alpha.inverse())
-            .floor() as usize)
+        let state = s.state().fetch().await?;
+        let computed_depth = (node_count as f32).log(state.alpha.inverse()).floor() as usize;
+        // ensure that the depth returned to trigger a re-balance is never higher than `state.max_depth`
+        Ok(computed_depth.min(state.max_depth))
     }
 }
 


### PR DESCRIPTION
This PR introduces a max depth in the scapegoat tree state, which is employed to trigger a re-balance in order to ensure that the depth of the tree is never higher than this max depth.