### PR TITLE
feat: provable commitment for off chain tables

### DIFF
--- a/mp2-v1/src/api.rs
+++ b/mp2-v1/src/api.rs
@@ -537,8 +537,8 @@ where
         let primary = row.primary_index.clone();
         grouped_rows
             .entry(primary)
-            .and_modify(|rows: &mut Vec<_>| rows.push(row.row_values.clone()))
-            .or_insert(vec![row.row_values.clone()]);
+            .and_modify(|rows: &mut Vec<_>| rows.push(&row.row_values))
+            .or_insert(vec![&row.row_values]);
     }
 
     // then, for each group of rows with the same primary index, compute the row value digest

--- a/mp2-v1/src/api.rs
+++ b/mp2-v1/src/api.rs
@@ -1,32 +1,37 @@
 //! Main APIs and related structures
 
-use std::{collections::BTreeSet, iter::once};
+use std::{
+    collections::{BTreeSet, HashMap},
+    fmt::Debug,
+    hash::Hash,
+    iter::once,
+};
 
 use crate::{
     block_extraction,
     contract_extraction::{self, compute_metadata_digest as contract_metadata_digest},
     final_extraction,
-    indexing::ColumnID,
+    indexing::{row::CellCollection, ColumnID},
     length_extraction::{
         self, compute_metadata_digest as length_metadata_digest, LengthCircuitInput,
     },
     values_extraction::{
         self, compute_leaf_mapping_metadata_digest,
         compute_leaf_mapping_of_mappings_metadata_digest, compute_leaf_single_metadata_digest,
-        gadgets::column_info::ColumnInfo, identifier_block_column,
+        compute_table_row_digest, gadgets::column_info::ColumnInfo, identifier_block_column,
         identifier_for_inner_mapping_key_column, identifier_for_mapping_key_column,
-        identifier_for_outer_mapping_key_column, identifier_for_value_column,
+        identifier_for_outer_mapping_key_column, identifier_for_value_column, ColumnId,
     },
     MAX_LEAF_NODE_LEN,
 };
-use alloy::primitives::Address;
-use anyhow::Result;
+use alloy::primitives::{Address, U256};
+use anyhow::{anyhow, Result};
 use itertools::Itertools;
 use log::debug;
 use mp2_common::{
     digest::Digest,
     group_hashing::map_to_curve_point,
-    poseidon::H,
+    poseidon::{flatten_poseidon_hash_value, H},
     types::HashOutput,
     utils::{Fieldable, ToFields},
     F,
@@ -36,7 +41,11 @@ use plonky2::{
     iop::target::Target,
     plonk::config::{GenericHashOut, Hasher},
 };
+use plonky2_ecgfp5::curve::curve::Point;
 use serde::{Deserialize, Serialize};
+use verifiable_db::{
+    block_tree::add_primary_index_to_digest, ivc::add_provable_data_commitment_prefix,
+};
 
 /// Struct containing the expected input MPT Extension/Branch node
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -467,8 +476,15 @@ pub(crate) fn no_provable_metadata_digest<I: IntoIterator<Item = ColumnID>>(
 }
 
 /// Compute the metadata hash for a table including no provable extraction data.
-/// The input is the set of the column identifiers of the table
-pub fn no_provable_metadata_hash<I: IntoIterator<Item = ColumnID>>(column_ids: I) -> MetadataHash {
+/// The input is the set of the column identifiers of the table.
+/// The input flag `provable_data_commitment` must be true if the root of trust being
+/// used to verify proofs over the table must be a commitment provably computed from the data
+/// inserted in the table, false when the root of trust is instead an existing
+/// commitment computed elsewhere (e.g., a block hash).
+pub fn no_provable_metadata_hash<I: IntoIterator<Item = ColumnID>>(
+    column_ids: I,
+    provable_data_commitment: bool,
+) -> MetadataHash {
     let metadata_digest = no_provable_metadata_digest(column_ids);
     // Add the prefix to the metadata digest to ensure the metadata digest
     // will keep track of whether we use this dummy circuit or not.
@@ -480,7 +496,74 @@ pub fn no_provable_metadata_hash<I: IntoIterator<Item = ColumnID>>(column_ids: I
         .collect_vec();
     let digest = map_to_curve_point(&inputs);
 
-    combine_digest_and_block(digest)
+    let metadata_hash = combine_digest_and_block(digest);
+    if provable_data_commitment {
+        // add the data commitment prefix to the metadata hash, to keep track
+        // of whether a commitment to the data of the table is used as root of trust
+        add_provable_data_commitment_prefix(metadata_hash)
+    } else {
+        metadata_hash
+    }
+}
+
+pub struct TableRow<PrimaryIndex> {
+    primary_index: PrimaryIndex,
+    row_values: CellCollection<PrimaryIndex>,
+}
+
+impl<PrimaryIndex> TableRow<PrimaryIndex> {
+    pub fn new(primary_index: PrimaryIndex, row_values: CellCollection<PrimaryIndex>) -> Self {
+        Self {
+            primary_index,
+            row_values,
+        }
+    }
+}
+
+/// Compute the provable commitment to the data found in an off-chain table
+pub fn off_chain_data_commitment<
+    PrimaryIndex: PartialEq + Eq + Default + Clone + Debug + Hash + TryInto<U256>,
+>(
+    table_rows: &[TableRow<PrimaryIndex>],
+    primary_index_column: ColumnID,
+    row_unique_columns: &[ColumnId],
+) -> Result<HashOutput>
+where
+    <PrimaryIndex as TryInto<U256>>::Error: Debug,
+{
+    // first, group rows by primary index values
+    let mut grouped_rows = HashMap::new();
+    for row in table_rows {
+        let primary = row.primary_index.clone();
+        grouped_rows
+            .entry(primary)
+            .and_modify(|rows: &mut Vec<_>| rows.push(row.row_values.clone()))
+            .or_insert(vec![row.row_values.clone()]);
+    }
+
+    // then, for each group of rows with the same primary index, compute the row value digest
+    let digest = grouped_rows
+        .into_iter()
+        .try_fold(Point::NEUTRAL, |acc, (primary, rows)| {
+            let row_digest = compute_table_row_digest(&rows, row_unique_columns)?;
+            // add primary index value to digest
+            let digest = add_primary_index_to_digest(
+                primary_index_column,
+                primary
+                    .try_into()
+                    .map_err(|e| anyhow!("while converting primary index to U256: {e:?}"))?,
+                row_digest,
+            );
+            // accumulate with the previous digest
+            anyhow::Ok(acc + digest)
+        })?;
+
+    // hash the digest
+    let hash_bytes = flatten_poseidon_hash_value(H::hash_no_pad(&digest.to_fields()))
+        .into_iter()
+        .flat_map(|f| (f.to_canonical_u64() as u32).to_le_bytes())
+        .collect_vec();
+    Ok(HashOutput::try_from(hash_bytes).unwrap())
 }
 
 #[cfg(test)]

--- a/mp2-v1/src/final_extraction/api.rs
+++ b/mp2-v1/src/final_extraction/api.rs
@@ -17,8 +17,8 @@ use serde::{Deserialize, Serialize};
 use std::fmt::Debug;
 
 use crate::{
-    api::no_provable_metadata_digest,
-    indexing::{row::CellCollection, ColumnID},
+    api::{no_provable_metadata_digest, TableRow},
+    indexing::ColumnID,
     values_extraction::compute_table_row_digest,
 };
 use verifiable_db::ivc::PublicInputs as IvcPublicInputs;
@@ -292,7 +292,7 @@ impl CircuitInput {
         primary_index: PrimaryIndex,
         root_of_trust: OffChainRootOfTrust,
         prev_epoch_proof: Option<Vec<u8>>,
-        table_rows: &[CellCollection<PrimaryIndex>],
+        table_rows: &[TableRow],
         row_unique_columns: &[ColumnID],
     ) -> Result<Self>
     where

--- a/mp2-v1/src/indexing/row.rs
+++ b/mp2-v1/src/indexing/row.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use std::{collections::HashSet, fmt::Debug};
 
 use super::{block::BlockPrimaryIndex, cell::CellTreeKey, ColumnID};
 use alloy::primitives::U256;
@@ -119,7 +119,7 @@ impl<PrimaryIndex> CellInfo<PrimaryIndex> {
 /// searchable format.
 #[derive(Eq, PartialEq, Deref, From, Default, Debug, Clone, Serialize, Deserialize)]
 pub struct CellCollection<PrimaryIndex>(pub HashMap<ColumnID, CellInfo<PrimaryIndex>>);
-impl<PrimaryIndex: PartialEq + Eq + Default + Clone> CellCollection<PrimaryIndex> {
+impl<PrimaryIndex: PartialEq + Eq + Default + Clone + Debug> CellCollection<PrimaryIndex> {
     pub fn update_column(&mut self, id: ColumnID, cell: CellInfo<PrimaryIndex>) {
         self.0.insert(id, cell);
     }

--- a/mp2-v1/src/indexing/row.rs
+++ b/mp2-v1/src/indexing/row.rs
@@ -153,6 +153,12 @@ impl<PrimaryIndex: PartialEq + Eq + Default + Clone + Debug> CellCollection<Prim
     }
 }
 
+impl<PrimaryIndex> AsRef<CellCollection<PrimaryIndex>> for CellCollection<PrimaryIndex> {
+    fn as_ref(&self) -> &CellCollection<PrimaryIndex> {
+        self
+    }
+}
+
 /// An utility wrapper to pass around that connects what we put in the JSON description and
 /// the actual row key used to insert in the tree
 #[derive(Clone, Debug, Default, PartialEq, Eq)]

--- a/mp2-v1/src/values_extraction/mod.rs
+++ b/mp2-v1/src/values_extraction/mod.rs
@@ -1,4 +1,4 @@
-use crate::api::SlotInput;
+use crate::api::{SlotInput, TableRow};
 use alloy::primitives::Address;
 use anyhow::{ensure, Result};
 use gadgets::{
@@ -35,8 +35,6 @@ pub mod public_inputs;
 
 pub use api::{build_circuits_params, generate_proof, CircuitInput, PublicParameters};
 pub use public_inputs::PublicInputs;
-
-use crate::indexing::row::CellCollection;
 
 /// Constant prefixes for the mapping key ID. Restrict to 4-bytes (Uint32).
 pub(crate) const KEY_ID_PREFIX: &[u8] = b"\0KEY";
@@ -524,10 +522,7 @@ fn compute_row_id(row_unique_data: HashOutput, num_actual_columns: usize) -> Sca
 
 /// Compute the row value digest of one table, taking as input the rows of the
 /// table and the identifiers of columns employed to compute the row unique data
-pub fn compute_table_row_digest<
-    PrimaryIndex: PartialEq + Eq + Default + Clone + Debug,
-    T: AsRef<CellCollection<PrimaryIndex>>,
->(
+pub fn compute_table_row_digest<T: AsRef<TableRow>>(
     table_rows: &[T],
     row_unique_columns: &[ColumnId],
 ) -> Result<Digest> {
@@ -548,12 +543,12 @@ pub fn compute_table_row_digest<
                 "row {i} has different column ids than other rows"
             );
             let current_row_digest =
-                current_column_ids
-                    .into_iter()
-                    .fold(Digest::NEUTRAL, |acc, id| {
+                row.other_columns
+                    .iter()
+                    .fold(Digest::NEUTRAL, |acc, column| {
                         let current = map_to_curve_point(
-                            &once(F::from_canonical_u64(id))
-                                .chain(row.find_by_column(id).unwrap().value.to_fields())
+                            &once(F::from_canonical_u64(column.identifier()))
+                                .chain(column.value().to_fields())
                                 .collect_vec(),
                         );
                         acc + current
@@ -562,12 +557,7 @@ pub fn compute_table_row_digest<
             let row_unique_data = {
                 let column_values = row_unique_columns
                     .iter()
-                    .map(|&id| {
-                        row.find_by_column(id)
-                            .unwrap()
-                            .value
-                            .to_be_bytes_trimmed_vec()
-                    })
+                    .map(|&id| row.find_by_column_id(id).unwrap().to_be_bytes_trimmed_vec())
                     .collect_vec();
                 row_unique_data(column_values.iter().map(|v| v.as_slice()))
             };

--- a/mp2-v1/src/values_extraction/mod.rs
+++ b/mp2-v1/src/values_extraction/mod.rs
@@ -524,11 +524,14 @@ fn compute_row_id(row_unique_data: HashOutput, num_actual_columns: usize) -> Sca
 
 /// Compute the row value digest of one table, taking as input the rows of the
 /// table and the identifiers of columns employed to compute the row unique data
-pub fn compute_table_row_digest<PrimaryIndex: PartialEq + Eq + Default + Clone + Debug>(
-    table_rows: &[CellCollection<PrimaryIndex>],
+pub fn compute_table_row_digest<
+    PrimaryIndex: PartialEq + Eq + Default + Clone + Debug,
+    T: AsRef<CellCollection<PrimaryIndex>>,
+>(
+    table_rows: &[T],
     row_unique_columns: &[ColumnId],
 ) -> Result<Digest> {
-    let column_ids = table_rows[0].column_ids();
+    let column_ids = table_rows[0].as_ref().column_ids();
     let num_actual_columns = column_ids.len();
     // check that the identifiers of row unique columns are actual identifiers of the columns
     // of the table
@@ -537,6 +540,7 @@ pub fn compute_table_row_digest<PrimaryIndex: PartialEq + Eq + Default + Clone +
         .iter()
         .enumerate()
         .fold(Digest::NEUTRAL, |acc, (i, row)| {
+            let row = row.as_ref();
             let current_column_ids = row.column_ids();
             // check that column ids are the same for each row
             assert_eq!(

--- a/mp2-v1/src/values_extraction/mod.rs
+++ b/mp2-v1/src/values_extraction/mod.rs
@@ -545,10 +545,10 @@ pub fn compute_table_row_digest<T: AsRef<TableRow>>(
             let current_row_digest =
                 row.other_columns
                     .iter()
-                    .fold(Digest::NEUTRAL, |acc, column| {
+                    .fold(Digest::NEUTRAL, |acc, (&id, &value)| {
                         let current = map_to_curve_point(
-                            &once(F::from_canonical_u64(column.identifier()))
-                                .chain(column.value().to_fields())
+                            &once(F::from_canonical_u64(id))
+                                .chain(value.to_fields())
                                 .collect_vec(),
                         );
                         acc + current

--- a/mp2-v1/tests/common/cases/indexing.rs
+++ b/mp2-v1/tests/common/cases/indexing.rs
@@ -714,7 +714,7 @@ impl TableIndexing {
             if prev_bn == bn {
                 continue;
             }
-            // if there is a new block on the chain, we need to prove a new block even if there are no 
+            // if there is a new block on the chain, we need to prove a new block even if there are no
             // updates in `table_row_updates`, otherwise the block consequentiality check in circuits will
             // fail
             log::info!("Applying follow up updates to contract done - now at block {bn}",);

--- a/mp2-v1/tests/common/final_extraction.rs
+++ b/mp2-v1/tests/common/final_extraction.rs
@@ -3,9 +3,10 @@ use mp2_common::{
     group_hashing::weierstrass_to_point, proof::ProofWithVK, types::HashOutput, utils::ToFields, F,
 };
 use mp2_v1::{
-    api, contract_extraction,
+    api::{self, TableRow},
+    contract_extraction,
     final_extraction::{CircuitInput, OffChainRootOfTrust, PublicInputs},
-    indexing::{block::BlockPrimaryIndex, row::CellCollection, ColumnID},
+    indexing::{block::BlockPrimaryIndex, ColumnID},
     values_extraction,
 };
 
@@ -31,7 +32,7 @@ pub(crate) struct OffChainExtractionProof {
     pub(crate) hash: OffChainRootOfTrust,
     pub(crate) prev_proof: Option<Vec<u8>>,
     pub(crate) primary_index: BlockPrimaryIndex,
-    pub(crate) rows: Vec<CellCollection<BlockPrimaryIndex>>,
+    pub(crate) rows: Vec<TableRow>,
     pub(crate) primary_key_columns: Vec<ColumnID>,
 }
 

--- a/mp2-v1/tests/common/mod.rs
+++ b/mp2-v1/tests/common/mod.rs
@@ -141,7 +141,10 @@ impl TableInfo {
                     mapping,
                 )
             }
-            TableSource::OffChain(off_chain) => no_provable_metadata_hash(off_chain.column_ids()),
+            TableSource::OffChain(off_chain) => no_provable_metadata_hash(
+                off_chain.column_ids(),
+                off_chain.provable_data_commitment,
+            ),
         }
     }
 }

--- a/mp2-v1/tests/integrated_tests.rs
+++ b/mp2-v1/tests/integrated_tests.rs
@@ -158,7 +158,7 @@ async fn integrated_indexing() -> Result<()> {
         ChangeType::Deletion,
     ];
     merged.run(&mut ctx, genesis, changes).await?;
-    let (mut off_chain, genesis) = TableIndexing::off_chain_test_case(&mut ctx).await?;
+    let (mut off_chain, genesis) = TableIndexing::off_chain_test_case(&mut ctx, true).await?;
     let changes = vec![
         ChangeType::Insertion,
         ChangeType::Update(UpdateType::Rest),

--- a/verifiable-db/src/block_tree/parent.rs
+++ b/verifiable-db/src/block_tree/parent.rs
@@ -1,7 +1,9 @@
 //! This circuit is employed when the new node is inserted as parent of an existing node,
 //! referred to as old node.
 
-use super::{compute_final_digest_target, compute_index_digest, public_inputs::PublicInputs};
+use super::{
+    compute_final_digest_target, compute_index_digest_target, public_inputs::PublicInputs,
+};
 use crate::{
     extraction::{ExtractionPI, ExtractionPIWrap},
     row_tree,
@@ -106,7 +108,7 @@ impl ParentCircuit {
         let inputs = iter::once(index_identifier)
             .chain(block_number.iter().cloned())
             .collect();
-        let node_digest = compute_index_digest(b, inputs, final_digest);
+        let node_digest = compute_index_digest_target(b, inputs, final_digest);
 
         // We recompute the hash of the old node to bind the `old_min` and `old_max`
         // values to the hash of the old tree.

--- a/verifiable-db/src/ivc/api.rs
+++ b/verifiable-db/src/ivc/api.rs
@@ -7,39 +7,63 @@ use recursion_framework::{
 };
 use serde::{Deserialize, Serialize};
 
-use super::circuit::{DummyCircuit, DummyWires, RecursiveIVCInput, RecursiveIVCWires};
+use super::circuit::{DummyCircuit, DummyWires, IVCCircuit, RecursiveIVCInput, RecursiveIVCWires};
 
 #[derive(Serialize, Deserialize)]
 pub enum CircuitInput {
     FirstProof {
+        provable_data_commitment: bool,
         dummy: DummyCircuit,
         block_proof: Vec<u8>,
     },
     SubsequentProof {
+        provable_data_commitment: bool,
         block_proof: Vec<u8>,
         prev_proof: Vec<u8>,
     },
 }
 
 impl CircuitInput {
-    pub fn new_first_input(block_proof: Vec<u8>) -> Result<Self> {
+    /// Build input for the first IVC proof being generated. Requires as inputs:
+    /// - `block_proof`: the proof of the block tree construction for the current block
+    /// - `provable_data_commitment`: this flag must be true iff a commitment to the data
+    ///     found in the tree has to be provably computed and used as a root of trust for
+    ///     the data
+    pub fn new_first_input(provable_data_commitment: bool, block_proof: Vec<u8>) -> Result<Self> {
         let p = ProofWithVK::deserialize(&block_proof)?;
         let pi = crate::block_tree::PublicInputs::<F>::from_slice(&p.proof.public_inputs);
         let block_hash = pi.prev_block_hash_fields();
-        let md = pi.metadata_hash();
+        let md = if provable_data_commitment {
+            IVCCircuit::add_provable_data_commitment_prefix(HashOut::try_from(pi.metadata_hash())?)
+        } else {
+            HashOut::try_from(pi.metadata_hash())?
+        };
+
         let z0 = pi.min_block_number()?;
         Ok(Self::FirstProof {
+            provable_data_commitment,
             dummy: DummyCircuit {
                 block_hash,
-                metadata_hash: HashOut::try_from(md)?,
+                metadata_hash: md,
                 z0,
             },
             block_proof,
         })
     }
 
-    pub fn new_subsequent_input(block_proof: Vec<u8>, prev_proof: Vec<u8>) -> Result<Self> {
+    /// Build input for any subsequent IVC proof being generated. Requires as inputs:
+    /// - `block_proof`: the proof of the block tree construction for the current block
+    /// - `prev_proof`:  the IVC proof generated for the previous block
+    /// - `provable_data_commitment`: this flag must be true iff a commitment to the data
+    ///     found in the tree has to be provably computed and used as a root of trust for
+    ///     the data
+    pub fn new_subsequent_input(
+        provable_data_commitment: bool,
+        block_proof: Vec<u8>,
+        prev_proof: Vec<u8>,
+    ) -> Result<Self> {
         Ok(Self::SubsequentProof {
+            provable_data_commitment,
             block_proof,
             prev_proof,
         })
@@ -77,16 +101,22 @@ impl PublicParameters {
         input: CircuitInput,
         block_set: &RecursiveCircuits<F, C, D>,
     ) -> Result<Vec<u8>> {
-        let (prev_proof, vd, block_proof) = match input {
-            CircuitInput::FirstProof { dummy, block_proof } => {
+        let (prev_proof, vd, provable_data_commitment, block_proof) = match input {
+            CircuitInput::FirstProof {
+                provable_data_commitment: commit_to_data,
+                dummy,
+                block_proof,
+            } => {
                 let dummy_proof = self.set.generate_proof(&self.dummy, [], [], dummy)?;
                 (
                     dummy_proof,
                     self.dummy.circuit_data().verifier_only.clone(),
+                    commit_to_data,
                     block_proof,
                 )
             }
             CircuitInput::SubsequentProof {
+                provable_data_commitment: commit_to_data,
                 block_proof,
                 prev_proof,
             } => {
@@ -94,12 +124,16 @@ impl PublicParameters {
                 (
                     prev_proof.proof,
                     self.ivc.circuit_data().verifier_only.clone(),
+                    commit_to_data,
                     block_proof,
                 )
             }
         };
         let block_proof = ProofWithVK::deserialize(&block_proof)?;
         let input = RecursiveIVCInput {
+            ivc: IVCCircuit {
+                provable_data_commitment,
+            },
             block_proof,
             block_set: block_set.clone(),
         };
@@ -126,8 +160,9 @@ mod test {
     use alloy::primitives::U256;
     use anyhow::Result;
     use mp2_common::{
+        group_hashing::weierstrass_to_point,
         keccak::PACKED_HASH_LEN,
-        poseidon::empty_poseidon_hash,
+        poseidon::{empty_poseidon_hash, flatten_poseidon_hash_value},
         utils::{FromFields, ToFields},
         C, D, F,
     };
@@ -137,7 +172,7 @@ mod test {
     use rand::{thread_rng, Rng};
     use recursion_framework::framework_testing::TestingRecursiveCircuits;
 
-    use crate::ivc::circuit::BLOCK_IO;
+    use crate::ivc::circuit::{test::compute_data_commitment, BLOCK_IO};
 
     #[test]
     fn ivc_api() -> Result<()> {
@@ -176,20 +211,34 @@ mod test {
             first_block_proof[0].clone(),
             block_set.verifier_data_for_input_proofs::<1>()[0].clone(),
         ));
-        let input = CircuitInput::new_first_input(first_block_proof.serialize()?)?;
+        let provable_data_commitment = thread_rng().gen();
+        let input = CircuitInput::new_first_input(
+            provable_data_commitment,
+            first_block_proof.serialize()?,
+        )?;
         println!("generating first ivc proof");
         let first_ivc_proof_buff =
             params.generate_proof(input, block_set.get_recursive_circuit_set())?;
         println!("checking first ivc proof");
         let (first_ivc_proof, _) = ProofWithVK::deserialize(&first_ivc_proof_buff)?.into();
-        {
+        let commitment = {
             let block_pi = crate::block_tree::PublicInputs::from_slice(&first_block_pi);
             let ivc_pi = crate::ivc::PublicInputs::<F>::from_slice(&first_ivc_proof.public_inputs);
             assert_eq!(
                 ivc_pi.merkle_root_hash_fields(),
                 block_pi.new_merkle_hash_field(),
             );
-            assert_eq!(ivc_pi.metadata_hash(), block_pi.metadata_hash(),);
+            assert_eq!(
+                ivc_pi.metadata_hash().to_vec(),
+                if provable_data_commitment {
+                    IVCCircuit::add_provable_data_commitment_prefix(HashOut::from_partial(
+                        block_pi.metadata_hash(),
+                    ))
+                    .to_fields()
+                } else {
+                    block_pi.metadata_hash().to_vec()
+                }
+            );
             // same value digest
             assert_eq!(
                 ivc_pi.value_set_digest_point(),
@@ -197,14 +246,22 @@ mod test {
             );
             assert_eq!(ivc_pi.z0_u256(), min);
             assert_eq!(ivc_pi.zi_u256(), min);
-            assert_eq!(ivc_pi.block_hash_fields(), block_pi.block_hash());
-        }
+            let commitment = if provable_data_commitment {
+                flatten_poseidon_hash_value(compute_data_commitment(&weierstrass_to_point(
+                    &block_pi.new_value_set_digest_point(),
+                )))
+            } else {
+                block_pi.block_hash()
+            };
+            assert_eq!(ivc_pi.block_hash_fields(), commitment);
+            commitment
+        };
 
         println!("Generating second block proof");
         let h_old = h_new;
         let h_new = HashOut::<F>::rand().to_fields();
         let next_block_number = (first_block_number + U256::from(1)).to_fields();
-        let prev_block_hash = block_hash;
+        let prev_block_hash = commitment;
         let next_block_hash = random_vector::<u32>(PACKED_HASH_LEN).to_fields();
         let next_value_digest = Point::rand().to_fields();
 
@@ -228,6 +285,7 @@ mod test {
         ));
         println!("Generating second IVC proof");
         let second_input = CircuitInput::new_subsequent_input(
+            provable_data_commitment,
             second_block_proof.serialize()?,
             first_ivc_proof_buff,
         )?;
@@ -241,14 +299,31 @@ mod test {
                 ivc_pi.merkle_root_hash_fields(),
                 block_pi.new_merkle_hash_field(),
             );
-            assert_eq!(ivc_pi.metadata_hash(), block_pi.metadata_hash(),);
+            assert_eq!(
+                ivc_pi.metadata_hash().to_vec(),
+                if provable_data_commitment {
+                    IVCCircuit::add_provable_data_commitment_prefix(HashOut::from_partial(
+                        block_pi.metadata_hash(),
+                    ))
+                    .to_fields()
+                } else {
+                    block_pi.metadata_hash().to_vec()
+                }
+            );
             // the two digest should be added together from first proof
             let exp_digest =
                 Point::from_fields(&next_value_digest) + Point::from_fields(&value_digest);
             assert_eq!(ivc_pi.value_set_digest_point(), exp_digest.to_weierstrass(),);
             assert_eq!(ivc_pi.z0_u256(), min);
             assert_eq!(ivc_pi.zi_u256(), U256::from_fields(&next_block_number));
-            assert_eq!(ivc_pi.block_hash_fields(), block_pi.block_hash());
+            assert_eq!(
+                ivc_pi.block_hash_fields(),
+                if provable_data_commitment {
+                    flatten_poseidon_hash_value(compute_data_commitment(&exp_digest))
+                } else {
+                    block_pi.block_hash()
+                }
+            );
         }
         Ok(())
     }

--- a/verifiable-db/src/ivc/circuit.rs
+++ b/verifiable-db/src/ivc/circuit.rs
@@ -1,19 +1,25 @@
 use alloy::primitives::U256;
+use itertools::Itertools;
 use mp2_common::{
     default_config,
     keccak::PACKED_HASH_LEN,
-    poseidon::empty_poseidon_hash,
+    poseidon::{empty_poseidon_hash, flatten_poseidon_hash_target, HashPermutation},
     proof::ProofWithVK,
     public_inputs::PublicInputCommon,
     serialization::{deserialize, serialize},
+    types::HashOutput,
     u256::{CircuitBuilderU256, UInt256Target, WitnessWriteU256},
-    utils::{TargetsConnector, ToTargets},
-    C, D, F,
+    utils::{HashBuilder, TargetsConnector, ToFields, ToTargets},
+    CHasher, C, D, F,
 };
 use plonky2::{
-    hash::hash_types::{HashOut, HashOutTarget},
+    field::types::Field,
+    hash::{
+        hash_types::{HashOut, HashOutTarget},
+        hashing::hash_n_to_hash_no_pad,
+    },
     iop::{
-        target::Target,
+        target::{BoolTarget, Target},
         witness::{PartialWitness, WitnessWrite},
     },
     plonk::circuit_builder::CircuitBuilder,
@@ -27,15 +33,51 @@ use recursion_framework::{
 };
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone)]
-struct IVCCircuit;
+const PROVABLE_DATA_COMMITMENT_PREFIX: &[u8] = b"DATA_COMMIT";
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct IVCCircuit {
+    pub(crate) provable_data_commitment: bool,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+struct IVCCircuitWires {
+    #[serde(serialize_with = "serialize", deserialize_with = "deserialize")]
+    pub(crate) commit_to_data: BoolTarget,
+}
+/// Add data commitment constant prefix to the metadata hash
+pub fn add_provable_data_commitment_prefix(metadata_hash: HashOutput) -> HashOutput {
+    let hash = IVCCircuit::add_provable_data_commitment_prefix(HashOut::from(metadata_hash));
+    HashOutput::from(hash)
+}
 
 impl IVCCircuit {
-    pub(crate) fn build(c: &mut CircuitBuilder<F, D>, block_pi: &[Target], prev_proof: &[Target]) {
+    fn build(
+        c: &mut CircuitBuilder<F, D>,
+        block_pi: &[Target],
+        prev_proof: &[Target],
+    ) -> IVCCircuitWires {
         assert_eq!(prev_proof.len(), super::NUM_IO);
         let _true = c._true();
         let block_pi = crate::block_tree::PublicInputs::from_slice(block_pi);
         let prev_pi = super::PublicInputs::from_slice(prev_proof);
+
+        // accumulate the order-agnostic digest of all the previously
+        // inserted nodes with the one of the new node
+        // expose prev_proof.DT + new_block_proof.new_node_digest as DT
+        let new_value_set_digest =
+            c.curve_add(prev_pi.value_set_digest(), block_pi.new_value_set_digest());
+        // compute block hash as the hash of multiset digest of the table in case `commit_to_data` is true
+        let data_hash = c.hash_n_to_hash_no_pad::<CHasher>(new_value_set_digest.to_targets());
+        let flattened_hash = flatten_poseidon_hash_target(c, data_hash);
+        let block_hash = block_pi.current_block_hash();
+        // select between flattener hash and block hash depending on `commit_to_data` flag
+        let commit_to_data = c.add_virtual_bool_target_safe();
+        let commitment = flattened_hash
+            .into_iter()
+            .zip_eq(block_hash)
+            .map(|(dh, bh)| c.select(commit_to_data, dh, bh))
+            .collect_vec();
 
         // This is the original blockchain hash
         // assert prev_proof.BH == new_block_proof.prev_block_hash
@@ -45,8 +87,27 @@ impl IVCCircuit {
         c.connect_targets(prev_pi.merkle_hash(), block_pi.old_merkle_hash());
         // assert prev_proof.z_0 == new_block_proof.min
         c.enforce_equal_u256(&prev_pi.z0(), &block_pi.min_value());
+        // compute metadata hash for new block: we add the constant DATA_COMMITMENT_ID depending on
+        // whether the exposed commitment is the commitment to the table data or not
+        let hash_payload = block_pi
+            .metadata_hash()
+            .to_targets()
+            .into_iter()
+            .chain(
+                PROVABLE_DATA_COMMITMENT_PREFIX
+                    .iter()
+                    .map(|b| c.constant(F::from_canonical_u8(*b))),
+            )
+            .collect_vec();
+        let data_commit_metadata_hash = c.hash_n_to_hash_no_pad::<CHasher>(hash_payload);
+        let metadata_hash = c.select_hash(
+            commit_to_data,
+            &data_commit_metadata_hash,
+            &HashOutTarget::from_vec(block_pi.metadata_hash().to_vec()),
+        );
+
         //assert prev_proof.M == new_block_proof.M
-        c.connect_targets(prev_pi.metadata_hash(), block_pi.metadata_hash());
+        c.connect_targets(prev_pi.metadata_hash(), &metadata_hash.to_targets());
 
         // if is_dummy(prev_proof):
         //	    assert new_block_proof.H_old == H("")
@@ -62,31 +123,47 @@ impl IVCCircuit {
         let final_cond = c.select(is_this_first_proof, andded.target, _true.target);
         c.connect(final_cond, _true.target);
 
-        // accumulate the order-agnostic digest of all the previously
-        // inserted nodes with the one of the new node
-        // expose prev_proof.DT + new_block_proof.new_node_digest as DT
-        let new_value_set_digest =
-            c.curve_add(prev_pi.value_set_digest(), block_pi.new_value_set_digest());
         super::PublicInputs::new(
             &block_pi.new_merkle_hash_target().to_targets(),
             prev_pi.metadata_hash(),
             &new_value_set_digest.to_targets(),
             &prev_pi.z0().to_targets(),
             block_pi.block_number,
-            &block_pi.current_block_hash(),
+            &commitment,
         )
         .register(c);
+
+        IVCCircuitWires { commit_to_data }
+    }
+
+    fn assign(&self, pw: &mut PartialWitness<F>, wires: &IVCCircuitWires) {
+        pw.set_bool_target(wires.commit_to_data, self.provable_data_commitment);
+    }
+
+    pub(crate) fn add_provable_data_commitment_prefix(mh: HashOut<F>) -> HashOut<F> {
+        let inputs = mh
+            .to_fields()
+            .into_iter()
+            .chain(
+                PROVABLE_DATA_COMMITMENT_PREFIX
+                    .iter()
+                    .map(|b| F::from_canonical_u8(*b)),
+            )
+            .collect_vec();
+        hash_n_to_hash_no_pad::<F, HashPermutation>(&inputs)
     }
 }
 
 pub(crate) const BLOCK_IO: usize = crate::block_tree::PublicInputs::<Target>::TOTAL_LEN;
 #[derive(Serialize, Deserialize)]
 pub struct RecursiveIVCWires {
+    ivc: IVCCircuitWires,
     block_verifier: RecursiveCircuitsVerifierTarget<D>,
 }
 
 #[derive(Clone, Debug)]
 pub struct RecursiveIVCInput {
+    pub(crate) ivc: IVCCircuit,
     pub(crate) block_proof: ProofWithVK,
     pub(crate) block_set: RecursiveCircuits<F, C, D>,
 }
@@ -112,11 +189,15 @@ impl CircuitLogicWires<F, D, 1> for RecursiveIVCWires {
         let block_pi = block_verifier.get_public_input_targets::<F, BLOCK_IO>();
 
         let prev_pi = Self::public_input_targets(verified_proofs[0]);
-        IVCCircuit::build(builder, block_pi, prev_pi);
-        RecursiveIVCWires { block_verifier }
+        let ivc = IVCCircuit::build(builder, block_pi, prev_pi);
+        RecursiveIVCWires {
+            ivc,
+            block_verifier,
+        }
     }
 
     fn assign_input(&self, inputs: Self::Inputs, pw: &mut PartialWitness<F>) -> anyhow::Result<()> {
+        inputs.ivc.assign(pw, &self.ivc);
         let (proof, vd) = inputs.block_proof.into();
         self.block_verifier
             .set_target(pw, &inputs.block_set, &proof, &vd)?;
@@ -204,26 +285,29 @@ impl CircuitLogicWires<F, D, 0> for DummyWires {
 }
 
 #[cfg(test)]
-mod test {
+pub(super) mod test {
 
     use anyhow::Result;
 
     use alloy::primitives::U256;
     use mp2_common::{
-        group_hashing::weierstrass_to_point, poseidon::empty_poseidon_hash, utils::ToFields, C, D,
-        F,
+        group_hashing::weierstrass_to_point,
+        poseidon::{empty_poseidon_hash, flatten_poseidon_hash_value, HashPermutation},
+        utils::ToFields,
+        C, D, F,
     };
     use mp2_test::circuit::{run_circuit, UserCircuit};
     use plonky2::{
-        hash::hash_types::HashOut,
+        hash::{hash_types::HashOut, hashing::hash_n_to_hash_no_pad},
         iop::{target::Target, witness::WitnessWrite},
     };
 
+    use plonky2_ecgfp5::curve::curve::Point;
     use rand::{thread_rng, Rng};
 
     use crate::{block_tree::tests::random_block_index_pi, ivc::circuit::DummyCircuit};
 
-    use super::{super::PublicInputs as IVCPI, DummyWires, IVCCircuit};
+    use super::{super::PublicInputs as IVCPI, DummyWires, IVCCircuit, IVCCircuitWires};
 
     impl UserCircuit<F, D> for DummyCircuit {
         type Wires = DummyWires;
@@ -239,34 +323,41 @@ mod test {
 
     #[derive(Debug, Clone)]
     struct TestCircuit {
+        c: IVCCircuit,
         prev_pi: Vec<F>,
         block_pi: Vec<F>,
     }
 
     impl UserCircuit<F, D> for TestCircuit {
-        type Wires = (Vec<Target>, Vec<Target>);
+        type Wires = (Vec<Target>, Vec<Target>, IVCCircuitWires);
 
         fn build(c: &mut plonky2::plonk::circuit_builder::CircuitBuilder<F, D>) -> Self::Wires {
             let prev_pi = c.add_virtual_targets(super::super::NUM_IO);
             let block_pi =
                 c.add_virtual_targets(crate::block_tree::PublicInputs::<Target>::TOTAL_LEN);
-            IVCCircuit::build(c, &block_pi, &prev_pi);
-            (prev_pi, block_pi)
+            let ivc = IVCCircuit::build(c, &block_pi, &prev_pi);
+            (prev_pi, block_pi, ivc)
         }
 
         fn prove(&self, pw: &mut plonky2::iop::witness::PartialWitness<F>, wires: &Self::Wires) {
             pw.set_target_arr(&wires.0, &self.prev_pi);
             pw.set_target_arr(&wires.1, &self.block_pi);
+            self.c.assign(pw, &wires.2);
         }
+    }
+
+    pub(crate) fn compute_data_commitment(value_digest: &Point) -> HashOut<F> {
+        let inputs = value_digest.to_fields();
+        hash_n_to_hash_no_pad::<F, HashPermutation>(&inputs)
     }
 
     #[test]
     fn ivc_circuit() -> Result<()> {
+        let rng = &mut thread_rng();
         // block_pi
-        let [min, max, block_number] =
-            [0; 3].map(|_| U256::from_limbs(thread_rng().gen::<[u64; 4]>()));
+        let [min, max, block_number] = [0; 3].map(|_| U256::from_limbs(rng.gen::<[u64; 4]>()));
         let minf: Vec<F> = min.to_fields();
-        let block_pi = random_block_index_pi(&mut thread_rng(), min, max, block_number);
+        let block_pi = random_block_index_pi(rng, min, max, block_number);
         let block_pi = crate::block_tree::PublicInputs::from_slice(&block_pi);
         // previous ivc_pi
         let z0 = min;
@@ -274,10 +365,19 @@ mod test {
         let zi = block_number - U256::from(1);
         let (z0f, zif) = (z0.to_fields(), zi.to_fields());
         // First case where we  construct a ivc pi which is not designated as the dummy first one
+        let commit_to_data = rng.gen();
+        let expected_metadata_hash = if commit_to_data {
+            IVCCircuit::add_provable_data_commitment_prefix(HashOut::from_partial(
+                block_pi.metadata_hash(),
+            ))
+            .to_fields()
+        } else {
+            block_pi.metadata_hash().to_vec()
+        };
         let prev_pi = IVCPI::new(
             // since this is the previous proof, we put the previous merkle root
             block_pi.h_old,
-            block_pi.metadata_hash(),
+            &expected_metadata_hash,
             block_pi.new_node_digest,
             &z0f,
             &zif,
@@ -287,6 +387,9 @@ mod test {
         let prev_pi_field = prev_pi.to_vec();
         assert_eq!(prev_pi_field.len(), crate::ivc::NUM_IO);
         let tc = TestCircuit {
+            c: IVCCircuit {
+                provable_data_commitment: commit_to_data,
+            },
             prev_pi: prev_pi_field.to_vec(),
             block_pi: block_pi.to_vec(),
         };
@@ -302,7 +405,7 @@ mod test {
                 pi.merkle_root_hash_fields(),
                 block_pi.new_merkle_hash_field()
             );
-            assert_eq!(pi.metadata_hash(), block_pi.metadata_hash());
+            assert_eq!(pi.metadata_hash(), &expected_metadata_hash,);
             // adding the previous value digest with the new block proof value digest
             let exp_set_digest = weierstrass_to_point(&prev_pi.value_set_digest_point())
                 + weierstrass_to_point(&block_pi.new_value_set_digest_point());
@@ -312,7 +415,14 @@ mod test {
             );
             assert_eq!(pi.z0_u256(), z0);
             assert_eq!(pi.zi_u256(), block_number);
-            assert_eq!(pi.block_hash_fields(), block_pi.block_hash());
+            assert_eq!(
+                pi.block_hash_fields(),
+                if commit_to_data {
+                    flatten_poseidon_hash_value(compute_data_commitment(&exp_set_digest))
+                } else {
+                    block_pi.block_hash()
+                }
+            );
         }
 
         //
@@ -320,10 +430,19 @@ mod test {
         // --------------------------------------------------------
         // Second case where we construct a ivc pi which is the dummy proof
         // we set min = max = block_number, and hash = empty, and zi = z0-1
+        let commit_to_data = rng.gen();
+        let expected_metadata_hash = if commit_to_data {
+            IVCCircuit::add_provable_data_commitment_prefix(HashOut::from_partial(
+                block_pi.metadata_hash(),
+            ))
+            .to_fields()
+        } else {
+            block_pi.metadata_hash().to_vec()
+        };
         let dummy_circuit = DummyCircuit {
             // we expose the previous block hash, that is not "proved" in our system
             block_hash: block_pi.prev_block_hash_fields(),
-            metadata_hash: HashOut::try_from(block_pi.metadata_hash())?,
+            metadata_hash: HashOut::try_from(expected_metadata_hash.as_slice())?,
             z0,
         };
         let proof = run_circuit::<F, D, C, _>(dummy_circuit);
@@ -342,8 +461,10 @@ mod test {
             block_pi.metadata_hash(),
             block_pi.new_node_digest,
         );
-
         let tc = TestCircuit {
+            c: IVCCircuit {
+                provable_data_commitment: commit_to_data,
+            },
             prev_pi: prev_pi.to_vec(),
             block_pi: block_pi.to_vec(),
         };
@@ -359,14 +480,23 @@ mod test {
                 pi.merkle_root_hash_fields(),
                 block_pi.new_merkle_hash_field()
             );
-            assert_eq!(pi.metadata_hash(), block_pi.metadata_hash(),);
+            assert_eq!(pi.metadata_hash(), &expected_metadata_hash);
             assert_eq!(
                 pi.value_set_digest_point(),
                 block_pi.new_value_set_digest_point()
             );
             assert_eq!(pi.z0_u256(), z0);
             assert_eq!(pi.zi_u256(), min);
-            assert_eq!(pi.block_hash_fields(), block_pi.block_hash());
+            assert_eq!(
+                pi.block_hash_fields(),
+                if commit_to_data {
+                    flatten_poseidon_hash_value(compute_data_commitment(&weierstrass_to_point(
+                        &block_pi.new_value_set_digest_point(),
+                    )))
+                } else {
+                    block_pi.block_hash()
+                }
+            );
         }
         Ok(())
     }

--- a/verifiable-db/src/ivc/mod.rs
+++ b/verifiable-db/src/ivc/mod.rs
@@ -3,6 +3,7 @@ mod circuit;
 pub(crate) mod public_inputs;
 
 pub use api::{CircuitInput, PublicParameters};
+pub use circuit::add_provable_data_commitment_prefix;
 use plonky2::iop::target::Target;
 pub use public_inputs::PublicInputs;
 pub const NUM_IO: usize = PublicInputs::<Target>::TOTAL_LEN;

--- a/verifiable-db/src/query/api.rs
+++ b/verifiable-db/src/query/api.rs
@@ -135,7 +135,7 @@ impl RowInput {
     }
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 #[allow(clippy::large_enum_variant)]
 pub enum CircuitInput<
     const NUM_CHUNKS: usize,


### PR DESCRIPTION
This PR adds the possibility to use a provable commitment to the data inserted in an off-chain table as a root of trust for such a table. It adds also a public API to re-compute the same commitment computed in circuits, which can be used to check that the zkTable has been built with the same data bound to the commitment.