### PR TITLE
feat: parsil: ensure number of parameters matches the number of placeholders

### DIFF
--- a/parsil/src/errors.rs
+++ b/parsil/src/errors.rs
@@ -30,6 +30,9 @@ pub enum ValidationError {
     #[error("`{0}` is not used")]
     MissingPlaceholder(String),
 
+    #[error("Too many query parameters. Expected {expected}, got {got}")]
+    TooManyParameters { expected: usize, got: usize },
+
     #[error("`{0}`: unsupported immediate value")]
     UnsupportedImmediateValue(String),
 

--- a/parsil/src/placeholders.rs
+++ b/parsil/src/placeholders.rs
@@ -43,13 +43,23 @@ impl<'a, C: ContextProvider> PlaceholderValidator<'a, C> {
         Ok(())
     }
 
-    /// Ensure that all the placeholders have been used, and return the largest
+    /// Ensure that all the placeholders have been used and that the number of
+    /// parameters matches the number of placeholders, and return the largest
     /// one found.
     fn ensured_used(&self) -> Result<usize> {
         for i in 0..self.current_max_freestanding {
             ensure!(
                 self.visited[i],
                 ValidationError::MissingPlaceholder(format!("${}", i + 1))
+            );
+        }
+        if let Some(parameters_count) = self.settings.placeholders.parameters_count.get() {
+            ensure!(
+                *parameters_count == self.current_max_freestanding,
+                ValidationError::TooManyParameters {
+                    expected: self.current_max_freestanding,
+                    got: *parameters_count,
+                }
             );
         }
         Ok(self.current_max_freestanding)

--- a/parsil/src/utils.rs
+++ b/parsil/src/utils.rs
@@ -1,7 +1,7 @@
 use alloy::primitives::U256;
 use anyhow::{anyhow, bail, ensure};
 use sqlparser::ast::{BinaryOperator, Expr, Query, UnaryOperator, Value};
-use std::cell::OnceCell;
+use std::sync::OnceLock;
 use std::str::FromStr;
 use verifiable_db::query::computational_hash_ids::PlaceholderIdentifier;
 
@@ -119,7 +119,7 @@ pub struct PlaceholderSettings {
     /// The maximum number of free-standing `$i` placeholders
     pub max_free_placeholders: usize,
     /// The number of provided parameters for placeholders, if any
-    pub parameters_count: OnceCell<usize>,
+    pub parameters_count: OnceLock<usize>,
 }
 
 pub const DEFAULT_MIN_BLOCK_PLACEHOLDER: &str = "$MIN_BLOCK";
@@ -157,7 +157,7 @@ impl PlaceholderSettings {
             min_block_placeholder: min_block.to_string(),
             max_block_placeholder: max_block.to_string(),
             max_free_placeholders: n,
-            parameters_count: OnceCell::new(),
+            parameters_count: OnceLock::new(),
         })
     }
 

--- a/parsil/src/utils.rs
+++ b/parsil/src/utils.rs
@@ -1,8 +1,8 @@
 use alloy::primitives::U256;
 use anyhow::{anyhow, bail, ensure};
 use sqlparser::ast::{BinaryOperator, Expr, Query, UnaryOperator, Value};
-use std::sync::OnceLock;
 use std::str::FromStr;
+use std::sync::OnceLock;
 use verifiable_db::query::computational_hash_ids::PlaceholderIdentifier;
 
 use crate::{

--- a/parsil/src/utils.rs
+++ b/parsil/src/utils.rs
@@ -1,6 +1,7 @@
 use alloy::primitives::U256;
-use anyhow::{bail, ensure};
+use anyhow::{anyhow, bail, ensure};
 use sqlparser::ast::{BinaryOperator, Expr, Query, UnaryOperator, Value};
+use std::cell::OnceCell;
 use std::str::FromStr;
 use verifiable_db::query::computational_hash_ids::PlaceholderIdentifier;
 
@@ -115,8 +116,10 @@ pub struct PlaceholderSettings {
     pub min_block_placeholder: String,
     /// The placeholder for the maximal value of the primary index
     pub max_block_placeholder: String,
-    /// The number of free-standing `$i` placeholders
+    /// The maximum number of free-standing `$i` placeholders
     pub max_free_placeholders: usize,
+    /// The number of provided parameters for placeholders, if any
+    pub parameters_count: OnceCell<usize>,
 }
 
 pub const DEFAULT_MIN_BLOCK_PLACEHOLDER: &str = "$MIN_BLOCK";
@@ -154,7 +157,16 @@ impl PlaceholderSettings {
             min_block_placeholder: min_block.to_string(),
             max_block_placeholder: max_block.to_string(),
             max_free_placeholders: n,
+            parameters_count: OnceCell::new(),
         })
+    }
+
+    /// Set the number of provided parameters for placeholders
+    pub fn with_parameters_count(self, parameters_count: usize) -> anyhow::Result<Self> {
+        self.parameters_count
+            .set(parameters_count)
+            .map_err(|_| anyhow!("parameters_count is already set"))?;
+        Ok(self)
     }
 
     /// Ensure that the given placeholder is valid, and update the validator


### PR DESCRIPTION
Currently, if the number of query parameters if greater than number of placeholders, the extraneous parameters are ignored. This change adds a validation check to prevent this