### PR TITLE
fix: resolving quoted freestanding symbols

### DIFF
--- a/parsil/src/symbols.rs
+++ b/parsil/src/symbols.rs
@@ -485,7 +485,7 @@ impl<M: Debug + Default, P: Debug + Clone> ScopeTable<M, P> {
     /// Resolve a free-standing (non-qualified) identifier in the current
     /// context.
     pub fn resolve_freestanding(&self, symbol: &Ident) -> Result<Symbol<P>> {
-        self.resolve_handle(&Handle::Simple(symbol.value.clone()))
+        self.resolve_handle(&Handle::Simple(symbol.to_string()))
     }
 
     /// Resolve a string identifier in the current context.


### PR DESCRIPTION
`Ident::to_string` will include quotes, if any (https://docs.rs/sqlparser/latest/src/sqlparser/ast/mod.rs.html#273-283)